### PR TITLE
Direct users to androidx stack overflow tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ tracking feature requests and bugs.
 Please see the
 [AndroidX Test Discuss mailing list](https://groups.google.com/forum/#!forum/androidx-test-discuss)
 for general questions and discussion, and please direct specific questions to
-[Stack Overflow](https://stackoverflow.com/questions/tagged/androidx-test).
+[Stack Overflow](https://stackoverflow.com/questions/tagged/androidx).


### PR DESCRIPTION
Until we have enough stack overflow cred to create our own androidx-test tag