### PR TITLE
Change the access modifier of ParcelableSubject to public.

### DIFF
--- a/ext/truth/java/androidx/test/ext/truth/os/ParcelableSubject.java
+++ b/ext/truth/java/androidx/test/ext/truth/os/ParcelableSubject.java
@@ -24,7 +24,7 @@ import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
 
 /** Testing subject for {@link Parcelable}s. */
-final class ParcelableSubject<T extends Parcelable> extends Subject<ParcelableSubject<T>, T> {
+public final class ParcelableSubject<T extends Parcelable> extends Subject<ParcelableSubject<T>, T> {
 
   public static <T extends Parcelable> ParcelableSubject<T> assertThat(T parcelable) {
     return Truth.assertAbout(ParcelableSubject.<T>parcelables()).that(parcelable);


### PR DESCRIPTION
It make possible to test `Parcelable` without writing a custom `Subject` class. 

resolve #238.