### PR TITLE
Migrate legacy gmaven_rules to rules_jvm_external

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//:__subpackages__"])
 
 load("//build_extensions:maven_repo.bzl", "maven_repository")
 load("//build_extensions:axt_versions.bzl", "ANDROIDX_VERSION", "ANDROIDX_LIFECYCLE_VERSION", "GOOGLE_MATERIAL_VERSION", "ANDROIDX_MULTIDEX_VERSION")
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("@rules_jvm_external//:defs.bzl", "artifact")
 
 exports_files([
     "proguard_binary.cfg",
@@ -56,70 +56,70 @@ alias(
 
 alias(
     name = "androidx_appcompat",
-    actual = gmaven_artifact("androidx.appcompat:appcompat:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.appcompat:appcompat:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "google_android_material",
-    actual = gmaven_artifact("com.google.android.material:material:aar:" + GOOGLE_MATERIAL_VERSION),
+    actual = artifact("com.google.android.material:material:" + GOOGLE_MATERIAL_VERSION),
 )
 
 alias(
     name = "androidx_multidex",
-    actual = gmaven_artifact("androidx.multidex:multidex:aar:" + ANDROIDX_MULTIDEX_VERSION),
+    actual = artifact("androidx.multidex:multidex:" + ANDROIDX_MULTIDEX_VERSION),
 )
 
 alias(
     name = "androidx_annotation",
-    actual = gmaven_artifact("androidx.annotation:annotation:jar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.annotation:annotation:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_lifecycle_common",
-    actual = gmaven_artifact("androidx.lifecycle:lifecycle-common:jar:" + ANDROIDX_LIFECYCLE_VERSION),
+    actual = artifact("androidx.lifecycle:lifecycle-common:" + ANDROIDX_LIFECYCLE_VERSION),
 )
 
 alias(
     name = "androidx_core",
-    actual = gmaven_artifact("androidx.core:core:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.core:core:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_legacy_support_core_ui",
-    actual = gmaven_artifact("androidx.legacy:legacy-support-core-ui:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-core-ui:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_legacy_support_core_utils",
-    actual = gmaven_artifact("androidx.legacy:legacy-support-core-utils:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-core-utils:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_fragment",
-    actual = gmaven_artifact("androidx.fragment:fragment:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.fragment:fragment:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_legacy_support_v4",
-    actual = gmaven_artifact("androidx.legacy:legacy-support-v4:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-v4:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_recyclerview",
-    actual = gmaven_artifact("androidx.recyclerview:recyclerview:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.recyclerview:recyclerview:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_viewpager",
-    actual = gmaven_artifact("androidx.viewpager:viewpager:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.viewpager:viewpager:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_drawerlayout",
-    actual = gmaven_artifact("androidx.drawerlayout:drawerlayout:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.drawerlayout:drawerlayout:" + ANDROIDX_VERSION),
 )
 
 alias(
     name = "androidx_cursoradapter",
-    actual = gmaven_artifact("androidx.cursoradapter:cursoradapter:aar:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.cursoradapter:cursoradapter:" + ANDROIDX_VERSION),
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//:__subpackages__"])
 
 load("//build_extensions:maven_repo.bzl", "maven_repository")
-load("//build_extensions:axt_versions.bzl", "ANDROIDX_VERSION", "ANDROIDX_LIFECYCLE_VERSION", "GOOGLE_MATERIAL_VERSION", "ANDROIDX_MULTIDEX_VERSION")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 
 exports_files([
@@ -56,70 +55,70 @@ alias(
 
 alias(
     name = "androidx_appcompat",
-    actual = artifact("androidx.appcompat:appcompat:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.appcompat:appcompat"),
 )
 
 alias(
     name = "google_android_material",
-    actual = artifact("com.google.android.material:material:" + GOOGLE_MATERIAL_VERSION),
+    actual = artifact("com.google.android.material:material"),
 )
 
 alias(
     name = "androidx_multidex",
-    actual = artifact("androidx.multidex:multidex:" + ANDROIDX_MULTIDEX_VERSION),
+    actual = artifact("androidx.multidex:multidex"),
 )
 
 alias(
     name = "androidx_annotation",
-    actual = artifact("androidx.annotation:annotation:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.annotation:annotation"),
 )
 
 alias(
     name = "androidx_lifecycle_common",
-    actual = artifact("androidx.lifecycle:lifecycle-common:" + ANDROIDX_LIFECYCLE_VERSION),
+    actual = artifact("androidx.lifecycle:lifecycle-common"),
 )
 
 alias(
     name = "androidx_core",
-    actual = artifact("androidx.core:core:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.core:core"),
 )
 
 alias(
     name = "androidx_legacy_support_core_ui",
-    actual = artifact("androidx.legacy:legacy-support-core-ui:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-core-ui"),
 )
 
 alias(
     name = "androidx_legacy_support_core_utils",
-    actual = artifact("androidx.legacy:legacy-support-core-utils:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-core-utils"),
 )
 
 alias(
     name = "androidx_fragment",
-    actual = artifact("androidx.fragment:fragment:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.fragment:fragment"),
 )
 
 alias(
     name = "androidx_legacy_support_v4",
-    actual = artifact("androidx.legacy:legacy-support-v4:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.legacy:legacy-support-v4"),
 )
 
 alias(
     name = "androidx_recyclerview",
-    actual = artifact("androidx.recyclerview:recyclerview:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.recyclerview:recyclerview"),
 )
 
 alias(
     name = "androidx_viewpager",
-    actual = artifact("androidx.viewpager:viewpager:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.viewpager:viewpager"),
 )
 
 alias(
     name = "androidx_drawerlayout",
-    actual = artifact("androidx.drawerlayout:drawerlayout:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.drawerlayout:drawerlayout"),
 )
 
 alias(
     name = "androidx_cursoradapter",
-    actual = artifact("androidx.cursoradapter:cursoradapter:" + ANDROIDX_VERSION),
+    actual = artifact("androidx.cursoradapter:cursoradapter"),
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,29 +3,65 @@ workspace(name = "android_test_support")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Google Maven Repository
-GMAVEN_COMMIT = "a5bc4640c35dd9b8234731678e9953f9fa64e0eb"
+RULES_JVM_EXTERNAL_TAG = "1.0"
+
+RULES_JVM_EXTERNAL_SHA = "48e0f1aab74fabba98feb8825459ef08dcc75618d381dff63ec9d4dd9860deaa"
 
 http_archive(
-    name = "gmaven_rules",
-    strip_prefix = "gmaven_rules-%s" % GMAVEN_COMMIT,
-    urls = ["https://github.com/aj-michael/gmaven_rules/archive/%s.tar.gz" % GMAVEN_COMMIT],
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
-load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load(
+    "//build_extensions:axt_versions.bzl",
+    "ANDROIDX_JUNIT_VERSION",
+    "ANDROIDX_LIFECYCLE_VERSION",
+    "ANDROIDX_MULTIDEX_VERSION",
+    "ANDROIDX_VERSION",
+    "CORE_VERSION",
+    "GOOGLE_MATERIAL_VERSION",
+    "RUNNER_VERSION",
+)
 
-gmaven_rules()
+maven_install(
+    name = "maven",
+    artifacts = [
+        "androidx.annotation:annotation:" + ANDROIDX_VERSION,
+        "androidx.appcompat:appcompat:" + ANDROIDX_VERSION,
+        "androidx.core:core:" + ANDROIDX_VERSION,
+        "androidx.cursoradapter:cursoradapter:" + ANDROIDX_VERSION,
+        "androidx.drawerlayout:drawerlayout:" + ANDROIDX_VERSION,
+        "androidx.fragment:fragment:" + ANDROIDX_VERSION,
+        "androidx.legacy:legacy-support-core-ui:" + ANDROIDX_VERSION,
+        "androidx.legacy:legacy-support-core-utils:" + ANDROIDX_VERSION,
+        "androidx.legacy:legacy-support-v4:" + ANDROIDX_VERSION,
+        "androidx.lifecycle:lifecycle-common:" + ANDROIDX_LIFECYCLE_VERSION,
+        "androidx.multidex:multidex:" + ANDROIDX_MULTIDEX_VERSION,
+        "androidx.recyclerview:recyclerview:" + ANDROIDX_VERSION,
+        "androidx.viewpager:viewpager:" + ANDROIDX_VERSION,
+        "com.google.android.material:material:" + GOOGLE_MATERIAL_VERSION,
+    ],
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
 
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "28.0.3")
+    build_tools_version = "28.0.3",
+)
 
 load("//:repo.bzl", "android_test_repositories")
 
 android_test_repositories(with_dev_repositories = True)
 
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
+
 robolectric_repositories()
 
 # Kotlin toolchains
@@ -33,11 +69,13 @@ rules_kotlin_version = "c5e25d71af96d446af4a8cb283c261537fc9f64e"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
+    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
     type = "zip",
-    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version
+    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
 )
 
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+
 kotlin_repositories()
+
 kt_register_toolchains()


### PR DESCRIPTION
### Overview

This PR migrates the repo to use the new Maven transitive resolver and fetch in https://github.com/bazelbuild/rules_jvm_external.

### Proposed Changes

This is a mechanical change that replaces `gmaven_rules` with `rules_jvm_external`, and `gmaven_artifact` with `artifact`. 

We also add an additional `maven_install` declaration to the WORKSPACE file to declare the top level targets we want to use.