### PR TITLE
Fix build with bazel version 0.23.2 (hopefully)

### DIFF
--- a/build_extensions/release.bzl
+++ b/build_extensions/release.bzl
@@ -2,6 +2,7 @@
 
 load("//build_extensions:remove_from_jar.bzl", "remove_from_jar")
 load("//build_extensions:add_or_update_file_in_zip.bzl", "add_or_update_file_in_zip")
+load("//build_extensions:jarjar.bzl", "jarjar_binary")
 
 def axt_release_lib(
     name,
@@ -79,15 +80,20 @@ def axt_release_lib(
     expected_output = ":%s_all_proguard.jar" % name
 
   # Step 3. Rename classes via jarjar
+  native.java_binary(
+    name = "jarjar_bin",
+    main_class = "com.tonicsystems.jarjar.Main",
+    runtime_deps = ["@bazel_tools//tools/jdk:JarJar"],
+  )
   native.genrule(
       name = "%s_jarjared" % name,
       srcs = [expected_output],
       outs = ["%s_jarjared.jar" % name],
-      cmd = ("$(location @bazel_tools//third_party/jarjar:jarjar_bin) process " +
+      cmd = ("$(location :jarjar_bin) process " +
                "$(location %s) '$<' '$@'") % jarjar_rules,
       tools = [
           jarjar_rules,
-          "@bazel_tools//third_party/jarjar:jarjar_bin",
+	  ":jarjar_bin",
       ],
   )
 

--- a/build_extensions/release.bzl
+++ b/build_extensions/release.bzl
@@ -2,7 +2,6 @@
 
 load("//build_extensions:remove_from_jar.bzl", "remove_from_jar")
 load("//build_extensions:add_or_update_file_in_zip.bzl", "add_or_update_file_in_zip")
-load("//build_extensions:jarjar.bzl", "jarjar_binary")
 
 def axt_release_lib(
     name,

--- a/ext/junit/javatests/androidx/test/ext/junit/runners/BUILD.bazel
+++ b/ext/junit/javatests/androidx/test/ext/junit/runners/BUILD.bazel
@@ -10,6 +10,7 @@ licenses(["notice"])  # Apache License 2.0
 android_local_test(
     name = "AndroidJUnit4Test",
     srcs = ["AndroidJUnit4Test.java"],
+    manifest = "AndroidManifest_target.xml",
     # TODO: have android_local_test provide this natively?
     jvm_flags = ["-Dandroid.junit.runner=org.robolectric.RobolectricTestRunner"],
     tags = ["robolectric"],

--- a/runner/monitor/javatests/androidx/test/internal/platform/BUILD.bazel
+++ b/runner/monitor/javatests/androidx/test/internal/platform/BUILD.bazel
@@ -32,6 +32,7 @@ android_local_test(
     name = "ServiceLoaderWrapperTest",
     srcs = ["ServiceLoaderWrapperTest.java"],
     tags = ["robolectric"],
+    manifest = "AndroidManifest_target.xml",
     deps = [
         ":robolectric_config",
         ":service_fixture",


### PR DESCRIPTION
Use jarjar from new location, and specify manifests for unit tests to
avoid min sdk errors.

