### PR TITLE
Update protobuf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,22 @@ Please see the
 [AndroidX Test Discuss mailing list](https://groups.google.com/forum/#!forum/androidx-test-discuss)
 for general questions and discussion, and please direct specific questions to
 [Stack Overflow](https://stackoverflow.com/questions/tagged/androidx-test).
+
+## Bazel integration
+
+To depend on this repository in Bazel, add the following snippet to your WORKSPACE file:
+
+```
+ATS_TAG = "<commit>"
+http_archive(
+    name = "android_test_support",
+    sha256 = "<sha256>",
+    strip_prefix = "android-test-%s" % ATS_TAG,
+    urls = ["https://github.com/android/android-test/archive/%s.tar.gz" % ATS_TAG],
+)
+load("@android_test_support//:repo.bzl", "android_test_repositories")
+android_test_repositories()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,4 @@ http_archive(
 )
 load("@android_test_support//:repo.bzl", "android_test_repositories")
 android_test_repositories()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-protobuf_deps()
 ```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ for general questions and discussion, and please direct specific questions to
 To depend on this repository in Bazel, add the following snippet to your WORKSPACE file:
 
 ```
-ATS_TAG = "<commit>"
+ATS_TAG = "<release-tag>"
 http_archive(
     name = "android_test_support",
-    sha256 = "<sha256>",
+    sha256 = "<sha256 of release>",
     strip_prefix = "android-test-%s" % ATS_TAG,
     urls = ["https://github.com/android/android-test/archive/%s.tar.gz" % ATS_TAG],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,16 +95,13 @@ android_sdk_repository(
 )
 
 load("//:repo.bzl", "android_test_repositories")
-
 android_test_repositories(with_dev_repositories = True)
 
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
-
 robolectric_repositories()
 
 # Kotlin toolchains
 rules_kotlin_version = "4c71740a1b63b785fc90afd8d4d4d5bfda527107"
-
 http_archive(
     name = "io_bazel_rules_kotlin",
     sha256 = "c0ca7b66d9f466067635482592634703bf0a648d51ec958f41796d43ca8256b3",
@@ -112,9 +109,9 @@ http_archive(
     type = "zip",
     urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
 )
-
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-
 kotlin_repositories()
-
 kt_register_toolchains()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -112,6 +112,3 @@ http_archive(
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 kotlin_repositories()
 kt_register_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-protobuf_deps()

--- a/repo.bzl
+++ b/repo.bzl
@@ -1,5 +1,7 @@
 """Skylark rules to setup the WORKSPACE in the opensource bazel world."""
 
+
+load("@com_google_protobuf//:protobuf_deps.bzl", _protobuf_deps = "protobuf_deps")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # These dependencies are required for *developing* this project.
@@ -141,10 +143,17 @@ def android_test_repositories(with_dev_repositories = False):
     native.bind(name = "six", actual = "@six_archive//:six")
 
     http_archive(
+        name = "bazel_skylib",
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+    )
+
+    http_archive(
         name = "com_google_protobuf",
-        strip_prefix = "protobuf-3.6.1.2",
-        sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.tar.gz"],
+        sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
+        strip_prefix = "protobuf-b4f193788c9f0f05d7e0879ea96cd738630e5d51",
+        # Commit from 2019-05-15, update to protobuf 3.8 when available.
+        url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
     )
 
     # Open source version of the google python flags library.

--- a/repo.bzl
+++ b/repo.bzl
@@ -138,9 +138,7 @@ def android_test_repositories(with_dev_repositories = False):
         url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
     )
 
-    # Needed by protobuf
-    native.bind(name = "six", actual = "@six_archive//:six")
-
+    # Protobuf dependency start
     http_archive(
         name = "com_google_protobuf",
         sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
@@ -148,6 +146,18 @@ def android_test_repositories(with_dev_repositories = False):
         # Commit from 2019-05-15, update to protobuf 3.8 when available.
         url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
     )
+
+    # Inlined protobuf's deps so we don't need users to add protobuf_deps() to their local WORKSPACE.
+    # From load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps").
+    if "zlib" not in native.existing_rules():
+        http_archive(
+            name = "zlib",
+            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+            strip_prefix = "zlib-1.2.11",
+            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+        )
+    # Protobuf dependency end
 
     http_archive(
         name = "bazel_skylib",

--- a/repo.bzl
+++ b/repo.bzl
@@ -138,7 +138,7 @@ def android_test_repositories(with_dev_repositories = False):
         url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
     )
 
-    # Protobuf dependency start
+    # Protobuf
     http_archive(
         name = "com_google_protobuf",
         sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
@@ -146,6 +146,8 @@ def android_test_repositories(with_dev_repositories = False):
         # Commit from 2019-05-15, update to protobuf 3.8 when available.
         url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
     )
+
+    # Protobuf's dependencies
 
     # Inlined protobuf's deps so we don't need users to add protobuf_deps() to their local WORKSPACE.
     # From load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps").
@@ -157,7 +159,6 @@ def android_test_repositories(with_dev_repositories = False):
             strip_prefix = "zlib-1.2.11",
             urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
         )
-    # Protobuf dependency end
 
     http_archive(
         name = "bazel_skylib",

--- a/repo.bzl
+++ b/repo.bzl
@@ -151,14 +151,13 @@ def android_test_repositories(with_dev_repositories = False):
 
     # Inlined protobuf's deps so we don't need users to add protobuf_deps() to their local WORKSPACE.
     # From load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps").
-    if "zlib" not in native.existing_rules():
-        http_archive(
-            name = "zlib",
-            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-            strip_prefix = "zlib-1.2.11",
-            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-        )
+    http_archive(
+        name = "zlib",
+        build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    )
 
     http_archive(
         name = "bazel_skylib",

--- a/repo.bzl
+++ b/repo.bzl
@@ -1,7 +1,6 @@
 """Skylark rules to setup the WORKSPACE in the opensource bazel world."""
 
 
-load("@com_google_protobuf//:protobuf_deps.bzl", _protobuf_deps = "protobuf_deps")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # These dependencies are required for *developing* this project.
@@ -143,17 +142,17 @@ def android_test_repositories(with_dev_repositories = False):
     native.bind(name = "six", actual = "@six_archive//:six")
 
     http_archive(
-        name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
-    )
-
-    http_archive(
         name = "com_google_protobuf",
         sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
         strip_prefix = "protobuf-b4f193788c9f0f05d7e0879ea96cd738630e5d51",
         # Commit from 2019-05-15, update to protobuf 3.8 when available.
         url = "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
+    )
+
+    http_archive(
+        name = "bazel_skylib",
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
     )
 
     # Open source version of the google python flags library.


### PR DESCRIPTION
Make downstream Android instrumentation tests compatible with `--incompatible_new_actions_api` by updating Protobuf

https://github.com/bazelbuild/rules_jvm_external/issues/148

cc @laurentlb