### PR TITLE
Set unified_launcher_head to PY2 to be compatible with --incompatible_use_python_toolchains

### DIFF
--- a/tools/android/emulator/BUILD.bazel
+++ b/tools/android/emulator/BUILD.bazel
@@ -123,6 +123,7 @@ py_binary(
     srcs = ["unified_launcher.py"],
     imports = ["../../.."],
     main = "unified_launcher.py",
+    python_version = "PY2",
     deps = [
         ":emulated_device",
         ":emulator_meta_data_pb_py_pb2",


### PR DESCRIPTION
See https://github.com/android/android-test/issues/373
See https://github.com/googlesamples/android-testing/issues/266
See https://github.com/bazelbuild/rules_jvm_external/issues/157