### PR TITLE
Migrate Unified Launcher to Python 3

### DIFF
--- a/repo.bzl
+++ b/repo.bzl
@@ -99,9 +99,9 @@ def android_test_repositories(with_dev_repositories = False):
     http_archive(
         name = "google_apputils",
         build_file = str(Label("//opensource:google-apputils.BUILD")),
-        sha256 = "47959d0651c32102c10ad919b8a0ffe0ae85f44b8457ddcf2bdc0358fb03dc29",
-        strip_prefix = "google-apputils-0.4.2",
-        url = "https://pypi.python.org/packages/69/66/a511c428fef8591c5adfa432a257a333e0d14184b6c5d03f1450827f7fe7/google-apputils-0.4.2.tar.gz",
+        sha256 = "3d863efb7f952485e8969a1cb0f6fef9bc100ef4283020cf0f6eb8a5ae98dae3",
+        strip_prefix = "google-apputils-eb14d358af7b82f71b5104f91161eb6c8848fbdc",
+        url = "https://github.com/jin/google-apputils/archive/eb14d358af7b82f71b5104f91161eb6c8848fbdc.zip",
     )
 
     http_archive(

--- a/tools/android/emulator/BUILD.bazel
+++ b/tools/android/emulator/BUILD.bazel
@@ -15,6 +15,8 @@
 # repository. So any Python code that contains "import tools.something" will
 # find //tools before @androidsdk//:tools.
 
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 proto_library(
@@ -27,11 +29,16 @@ java_proto_library(
     deps = [":emulator_meta_data_pb"],
 )
 
-py_library(
+py_proto_library(
     name = "emulator_meta_data_pb_py_pb2",
-    srcs = ["emulator_meta_data_pb2.py"],
-    deps = ["@com_google_protobuf//:protobuf_python"],
+    srcs = [":emulator_meta_data.proto"],
 )
+
+# py_library(
+#     name = "emulator_meta_data_pb_py_pb2",
+#     srcs = ["emulator_meta_data_pb2.py"],
+#     deps = ["@com_google_protobuf//:protobuf_python"],
+# )
 
 MOX = "@mox_archive//:mox"
 

--- a/tools/android/emulator/resources.py
+++ b/tools/android/emulator/resources.py
@@ -27,9 +27,8 @@ def GetRunfilesDir():
   return FindRunfilesDir(os.path.abspath(starting_point))
 
 
-def GetResourceAsFile(file_path):
-  return open(GetResourceFilename(file_path))
-
+def GetResourceAsFile(file_path, mode='r'):
+  return open(GetResourceFilename(file_path), mode=mode)
 
 def GetResourceFilename(file_path):
   if os.path.isabs(file_path):

--- a/tools/android/emulator/unified_launcher.py
+++ b/tools/android/emulator/unified_launcher.py
@@ -17,11 +17,11 @@
 
 
 import collections
-import ConfigParser
+import configparser
 import json
 import logging
 import os
-import StringIO
+import io
 import subprocess
 import sys
 import tempfile
@@ -465,25 +465,25 @@ def _RestartDevice(device,
 
   if 'x86' == proto.emulator_architecture:
     if not _IsKvmPresent():
-      print ''
-      print '=' * 80
-      print ('= By activating KVM on your local host you can increase the '
+      print('')
+      print('=' * 80)
+      print('= By activating KVM on your local host you can increase the '
              'speed of the emulator.      =')
-      print '=' * 80
+      print('=' * 80)
     elif not proto.with_kvm:
-      print ''
-      print '=' * 80
-      print ('= Please add --no to your bazel command line, to create '
+      print('')
+      print('=' * 80)
+      print('= Please add --no to your bazel command line, to create '
              'snapshot images   =')
-      print ('= local with KVM support. This will increase the speed of the '
+      print('= local with KVM support. This will increase the speed of the '
              'emulator.        =')
-      print '=' * 80
+      print('=' * 80)
   else:
-    print ''
-    print '=' * 80
-    print ('= By using x86 with KVM on your local host you can increase the '
+    print('')
+    print('=' * 80)
+    print('= By using x86 with KVM on your local host you can increase the '
            'speed of the emulator.')
-    print '=' * 80
+    print('=' * 80)
 
   proto.system_image_dir = system_images_dir
   sysimg = (
@@ -748,9 +748,9 @@ def _TryToConvertIniStyleFileToDict(ini_style_file):
   if ini_style_file:
     with open(ini_style_file) as real_text_handle:
       text = real_text_handle.read()
-      filehandle = StringIO.StringIO('[android]\n' + text)
+      filehandle = io.StringIO(u'[android]\n' + text)
       try:
-        config = ConfigParser.ConfigParser()
+        config = configparser.ConfigParser()
         config.readfp(filehandle)
         return dict(config.items('android'))
       finally:
@@ -1060,9 +1060,9 @@ def _IsKvmPresent():
   kernel_module = os.access('/sys/class/misc/kvm/dev', os.R_OK)
   device_node = os.access(kvm_device, os.R_OK | os.W_OK)
   if not kernel_module:
-    print 'KVM Kernel module not readable.'
+    print('KVM Kernel module not readable.')
   if not device_node:
-    print '%s: not readable or writable by current user' % kvm_device
+    print('%s: not readable or writable by current user' % kvm_device)
 
   return device_node and kernel_module
 


### PR DESCRIPTION
Migrate unified launcher to Python 3 so users do not need to pass `--host_force_python=PY2`.

Current status with `$ bazel run //tools/android/emulated_devices/generic_phone:android_23_x86_qemu2 --host_force_python=PY3`:

```
ERROR: /usr/local/google/home/jingwen/code/android-test/tools/android/emulated_devices/generic_phone/BUILD.bazel:43:1: Creating Android image for //tools/android/emulated_devices/generic_phone:android_23_x86_qemu2 failed (Exit 1) unified_launcher_head failed: error executing command bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head '--action=boot' '--density=240' '--memory=2048' '--cache=32' '--vm_size=256' ... (remaining 17 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
W0604 13:29:54.484687 140571240703744 unified_launcher.py:978] Cannot find runfiles (via env vars). Defaulting to $CWD.
W0604 13:29:54.485357 140571240703744 unified_launcher.py:978] Cannot find runfiles (via env vars). Defaulting to $CWD.
I0604 13:29:54.487696 140571240703744 emulated_device.py:568] Copying system image to /tmp/tmpm943tumeandroid-emulator-launch/images/session/system.img
I0604 13:29:54.949253 140571240703744 emulated_device.py:3473] Running debugfs commands: ['unlink /vendor/lib/egl']
debugfs 1.44.1 (24-Mar-2018)
5982 blocks
25738 blocks
I0604 13:29:55.988053 140571240703744 emulated_device.py:717] Making sdcard on the fly due to a nonstandard size
I0604 13:29:56.218102 140571240703744 emulated_device.py:288] Emulator type: 2
I0604 13:29:56.656274 140571240703744 emulated_device.py:1790] Executing: ['/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/external/androidsdk/emulator/emulator', '-ports', '22548,21129', '-skin', '480x800', '-timezone', 'America/Los_Angeles', '-cache', 'cache.img', '-memory', '2048', '-sdcard', 'sdcard.img', '-ramdisk', 'ramdisk.img', '-partition-size', '2047', '-no-snapshot-save', '-verbose', '-unix-pipe', 'sockets/qemu.mgmt', '-unix-pipe', 'sockets/device-forward-server', '-unix-pipe', 'sockets/tar-pull-server', '-unix-pipe', 'sockets/exec-server', '-unix-pipe', 'sockets/tar-push-server', '-unix-pipe', 'sockets/h2o', '-writable-system', '-show-kernel', '-engine', 'qemu2', '-kernel', 'kernel-ranchu', '-system', 'system.img', '-feature', 'AllowSnapshotMigration', '-feature', '-GLDMA', '-feature', '-OnDemandSnapshotLoad', '-data', 'userdata-qemu.img', '-gpu', 'swiftshader_indirect', '-no-audio', '-no-boot-anim', '-selinux', 'disabled', '-fixed-scale', '-netdelay', 'none', '-netspeed', 'full', '-avd', 'mobile_ninjas.adb.21129', '-qemu', '-enable-kvm', '-L', '/tmp/tmpm943tumeandroid-emulator-launch/bios', '-append', 'enable_test_harness=1']
I0604 13:29:56.659971 140571240703744 emulated_device.py:1824] Launching emulator in: /tmp/tmpm943tumeandroid-emulator-launch/images/session
I0604 13:29:56.660338 140571240703744 emulated_device.py:1830] Write emulator log to /tmp/emulator_g5czyycc.log
I0604 13:29:56.661407 140571240703744 emulated_device.py:2409] system: False pm: False adb: False sdcard: False boot_complete: False launcher: False pipes: False current step attempts: 0 total attempts: 0
I0604 13:29:56.661873 140571240703744 emulated_device.py:3946] Checking if adb is listening.
I0604 13:29:56.915422 140571240703744 emulated_device.py:2409] system: False pm: False adb: False sdcard: False boot_complete: False launcher: False pipes: False current step attempts: 1 total attempts: 1
I0604 13:29:56.916013 140571240703744 emulated_device.py:3891] Emulator log below ==================================================

I0604 13:29:56.916224 140571240703744 emulated_device.py:3892] Emulator log end ==================================================
I0604 13:29:56.916636 140571240703744 emulated_device.py:3891] watchdog.out below ==================================================

I0604 13:29:56.916829 140571240703744 emulated_device.py:3892] watchdog.out end ==================================================
I0604 13:29:56.917149 140571240703744 emulated_device.py:3891] watchdog.err below ==================================================
I0604 13:29:56.687589 140571240703744 emulated_device.py:1974] Starting pipe services.

I0604 13:29:56.917346 140571240703744 emulated_device.py:3892] watchdog.err end ==================================================
Traceback (most recent call last):
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/unified_launcher.py", line 1129, in <module>
    app.run(main)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/absl_py/absl/app.py", line 262, in run
    _run_main(main, argv)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/absl_py/absl/app.py", line 227, in _run_main
    sys.exit(main(argv))
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/unified_launcher.py", line 1099, in main
    EntryPoint(reporter)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/unified_launcher.py", line 920, in EntryPoint
    mini_boot)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/unified_launcher.py", line 367, in _FirstBootAtBuildTimeOnly
    modified_ramdisk_path=modified_ramdisk_path)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/emulated_device.py", line 1267, in StartDevice
    loading_from_snapshot=loading_from_snapshot)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/emulated_device.py", line 1838, in _StartEmulator
    self._PollEmulatorStatus(timer, loading_from_snapshot=loading_from_snapshot)
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/emulated_device.py", line 2410, in _PollEmulatorStatus
    self._EnsureEmuRunning()
  File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/c0b8e7c3fe9b878a4633a5ff9d0fc340/sandbox/linux-sandbox/4/execroot/android_test_support/bazel-out/host/bin/external/android_test_support/tools/android/emulator/unified_launcher_head.runfiles/android_test_support/tools/android/emulator/emulated_device.py", line 3920, in _EnsureEmuRunning
    (wait_result >> 8, wait_result & 0xF))
Exception: Emulator has died, exit status 1, signal 0
----------------
Note: The above Python target's failure (exit code 1) may have been caused by the fact that it is a Python 2 program that was built in the host configuration, which uses Python 3. You can change the host configuration (for the entire build) to instead use Python 2 by setting --host_force_python=PY2.

You are likely seeing this message because the way Bazel locates the Python interpreter changed in 0.27. See https://github.com/bazelbuild/bazel/issues/7899 for more information.
----------------
debugfs: unlink /vendor/lib/egl
If you want to add certificates to the emulator, Please install MCrypt library using sudo apt-get install python-mcrypt .
Target //tools/android/emulated_devices/generic_phone:android_23_x86_qemu2 failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.664s, Critical Path: 3.25s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```