### PR TITLE
Fix AdbController's instrumentation class name enforcement.

### DIFF
--- a/opensource/README.md
+++ b/opensource/README.md
@@ -1,0 +1,7 @@
+entry_point_deploy.jar is used by bazel to run android_instrumentation_tests.
+
+To rebuild:
+bazel build
+tools/device_broker/java/com/google/android/apps/common/testing/suite:entry_point_deploy.jar
+cp
+bazel-bin/tools/device_broker/java/com/google/android/apps/common/testing/suite/entry_point_deploy.jar opensource/

--- a/opensource/README.md
+++ b/opensource/README.md
@@ -1,7 +1,7 @@
 entry_point_deploy.jar is used by bazel to run android_instrumentation_tests.
 
-To rebuild:
-bazel build
-tools/device_broker/java/com/google/android/apps/common/testing/suite:entry_point_deploy.jar
-cp
-bazel-bin/tools/device_broker/java/com/google/android/apps/common/testing/suite/entry_point_deploy.jar opensource/
+To rebuild (from project root):
+```
+bazel build tools/device_broker/java/com/google/android/apps/common/testing/suite:entry_point_deploy.jar
+cp bazel-bin/tools/device_broker/java/com/google/android/apps/common/testing/suite/entry_point_deploy.jar opensource/
+```

--- a/tools/device_broker/java/com/google/android/apps/common/testing/broker/AdbController.java
+++ b/tools/device_broker/java/com/google/android/apps/common/testing/broker/AdbController.java
@@ -93,8 +93,10 @@ public class AdbController {
       ImmutableList.<String>builder()
           .addAll(GOOGLE_INSTRUMENTATION_NAMES)
           .add("com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner")
+          .add(".GoogleInstrumentationTestRunner")
           .add("androidx.test.runner.AndroidJUnitRunner")
           .add("android.support.test.runner.AndroidJUnitRunner")
+          .add(".AndroidJUnitRunner")
           .build();
 
   /**

--- a/tools/device_broker/java/com/google/android/apps/common/testing/broker/AdbController.java
+++ b/tools/device_broker/java/com/google/android/apps/common/testing/broker/AdbController.java
@@ -93,10 +93,8 @@ public class AdbController {
       ImmutableList.<String>builder()
           .addAll(GOOGLE_INSTRUMENTATION_NAMES)
           .add("com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner")
-          .add(".GoogleInstrumentationTestRunner")
           .add("androidx.test.runner.AndroidJUnitRunner")
           .add("android.support.test.runner.AndroidJUnitRunner")
-          .add(".AndroidJUnitRunner")
           .build();
 
   /**

--- a/tools/device_broker/java/com/google/android/apps/common/testing/broker/Instrumentation.java
+++ b/tools/device_broker/java/com/google/android/apps/common/testing/broker/Instrumentation.java
@@ -48,6 +48,16 @@ public abstract class Instrumentation {
     return getAndroidPackage() + "/" + getInstrumentationClass();
   }
 
+  /**
+   * Return the fully qualified class name of the instrumentation.
+   */
+  public String getFullInstrumentationClass() {
+    if (getInstrumentationClass().startsWith(".")) {
+      return getAndroidPackage() + getInstrumentationClass();
+    }
+    return getInstrumentationClass();
+  }
+
   @Override
   public String toString() {
     return getFullName();

--- a/tools/device_broker/java/com/google/android/apps/common/testing/broker/InstrumentationRepository.java
+++ b/tools/device_broker/java/com/google/android/apps/common/testing/broker/InstrumentationRepository.java
@@ -114,7 +114,11 @@ class InstrumentationRepository {
                 "Ignoring instrumentation class: %s/%s",
                 instrumentation.getAndroidPackage(), instrumentation.getInstrumentationClass()));
       } else if (AdbController.SUPPORTED_INSTRUMENTATION_NAMES.contains(
-          instrumentation.getFullInstrumentationClass())) {
+              instrumentation.getFullInstrumentationClass())
+          ||
+          // TODO(b/150524968): remove support for custom runner classes
+          AdbController.SUPPORTED_INSTRUMENTATION_NAMES.contains(
+              instrumentation.getInstrumentationClass())) {
         filteredInstrumentations.add(instrumentation);
 
         // Assume the first supported non-bootstrap instrumentation found also contains the tests.

--- a/tools/device_broker/java/com/google/android/apps/common/testing/broker/InstrumentationRepository.java
+++ b/tools/device_broker/java/com/google/android/apps/common/testing/broker/InstrumentationRepository.java
@@ -114,7 +114,7 @@ class InstrumentationRepository {
                 "Ignoring instrumentation class: %s/%s",
                 instrumentation.getAndroidPackage(), instrumentation.getInstrumentationClass()));
       } else if (AdbController.SUPPORTED_INSTRUMENTATION_NAMES.contains(
-          instrumentation.getInstrumentationClass())) {
+          instrumentation.getFullInstrumentationClass())) {
         filteredInstrumentations.add(instrumentation);
 
         // Assume the first supported non-bootstrap instrumentation found also contains the tests.


### PR DESCRIPTION
Recognize cases like 'androidx.test/.runner.AndroidJUnitRunner', but
not 'com.somepackage/.AndroidJUnitRunner'

