### PR TITLE
Check for null reference

### DIFF
--- a/espresso/intents/java/androidx/test/espresso/intent/Intents.java
+++ b/espresso/intents/java/androidx/test/espresso/intent/Intents.java
@@ -138,7 +138,9 @@ public final class Intents {
 
   /** Clears Intents state. Must be called after each test case. */
   public static void release() {
-    defaultInstance.internalRelease();
+    if (defaultInstance != null) {
+      defaultInstance.internalRelease();
+    }
   }
 
   /**


### PR DESCRIPTION
Check for null `defaultInstance` member before invoking `internalRelease()`

### Overview

When running tests in Android studio, I have routinely seen this error:
![image](https://user-images.githubusercontent.com/13140065/79723607-e95d4600-829a-11ea-960f-abddd6e424b6.png)

### Proposed Changes

This pull request checks for a null reference before called in the `internalRelease()` method.
