### PR TITLE
Increase InstrumentationResultPrinter.MAX_TRACE_SIZE

### DIFF
--- a/runner/android_junit_runner/java/androidx/test/internal/runner/listener/InstrumentationResultPrinter.java
+++ b/runner/android_junit_runner/java/androidx/test/internal/runner/listener/InstrumentationResultPrinter.java
@@ -45,7 +45,7 @@ public class InstrumentationResultPrinter extends InstrumentationRunListener {
 
   private static final String TAG = "InstrumentationResultPrinter";
 
-  @VisibleForTesting static final int MAX_TRACE_SIZE = 32 * 1024;
+  @VisibleForTesting static final int MAX_TRACE_SIZE = 64 * 1024;
 
   /**
    * This value, if stored with key {@link android.app.Instrumentation#REPORT_KEY_IDENTIFIER},


### PR DESCRIPTION
This change increases InstrumentationResultPrinter.MAX_TRACE_SIZE from 65,536 bytes to 131,072 bytes, giving more room for long stacktraces (think RxJava and also view hierarchy logged as part of the trace message).

Also attempts to fallback to getTrimmedTrace() before actively trimming the trace at a random point.
