### PR TITLE
Add explicit launch to activityscenariorule

### DIFF
--- a/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleTest.java
+++ b/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleTest.java
@@ -15,17 +15,19 @@
  */
 package androidx.test.ext.junit.rules;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import android.app.Activity;
+
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.testing.RecreationRecordingActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.runner.lifecycle.Stage;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Tests for {@link ActivityScenarioRule}. */
 @RunWith(AndroidJUnit4.class)
@@ -35,7 +37,7 @@ public final class ActivityScenarioRuleTest {
       new ActivityScenarioRule<>(RecreationRecordingActivity.class);
 
   @Test
-  public void activityShouldBeResumedAutomatically() throws Exception {
+  public void activityShouldBeResumedAutomatically() {
     activityScenarioRule
         .getScenario()
         .onActivity(
@@ -46,7 +48,7 @@ public final class ActivityScenarioRuleTest {
   }
 
   @Test
-  public void recreateActivityShouldWork() throws Exception {
+  public void recreateActivityShouldWork() {
     activityScenarioRule.getScenario().recreate();
     activityScenarioRule
         .getScenario()
@@ -58,12 +60,13 @@ public final class ActivityScenarioRuleTest {
   }
 
   @Test
-  public void activityCanBeDestroyedManually() throws Exception {
+  public void activityCanBeDestroyedManually() {
     activityScenarioRule.getScenario().moveToState(Lifecycle.State.DESTROYED);
+    activityScenarioRule.getScenario();
   }
 
   @Test
-  public void activityCanBeClosedManually() throws Exception {
+  public void activityCanBeClosedManually() {
     activityScenarioRule.getScenario().close();
   }
 

--- a/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithCustomIntentTest.java
+++ b/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithCustomIntentTest.java
@@ -15,19 +15,21 @@
  */
 package androidx.test.ext.junit.rules;
 
-import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
-import static androidx.test.ext.truth.content.IntentSubject.assertThat;
-import static com.google.common.truth.Truth.assertThat;
-
 import android.app.Activity;
 import android.content.Intent;
+
 import androidx.test.core.app.testing.RecreationRecordingActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.runner.lifecycle.Stage;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static androidx.test.ext.truth.content.IntentSubject.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 /** Tests for {@link ActivityScenarioRule} using custom intent to start activity. */
 @RunWith(AndroidJUnit4.class)
@@ -39,7 +41,7 @@ public final class ActivityScenarioRuleWithCustomIntentTest {
               .putExtra("MyIntentParameterKey", "MyIntentParameterValue"));
 
   @Test
-  public void activityShouldBeResumedAutomatically() throws Exception {
+  public void activityShouldBeResumedAutomatically() {
     activityScenarioRule
         .getScenario()
         .onActivity(
@@ -54,7 +56,7 @@ public final class ActivityScenarioRuleWithCustomIntentTest {
   }
 
   @Test
-  public void recreateActivityShouldWork() throws Exception {
+  public void recreateActivityShouldWork() {
     activityScenarioRule.getScenario().recreate();
     activityScenarioRule
         .getScenario()

--- a/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithExplicitLaunchTest.java
+++ b/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithExplicitLaunchTest.java
@@ -1,0 +1,67 @@
+package androidx.test.ext.junit.rules;
+
+import android.app.Activity;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.testing.RecreationRecordingActivity;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+/** Tests for {@link ActivityScenarioRule} using explicit launch to start activity. */
+@RunWith(AndroidJUnit4.class)
+public final class ActivityScenarioRuleWithExplicitLaunchTest {
+
+  @Rule
+  public ActivityScenarioRule<RecreationRecordingActivity> activityScenarioRule =
+          new ActivityScenarioRule<>(RecreationRecordingActivity.class, null, false);
+
+  @Test
+  public void activityShouldBeResumedAutomatically() {
+    activityScenarioRule
+            .getScenario()
+            .onActivity(
+                    activity -> {
+                      assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED);
+                      assertThat(activity.getNumberOfRecreations()).isEqualTo(0);
+                    });
+  }
+
+  @Test
+  public void recreateActivityShouldWork() {
+    activityScenarioRule.getScenario().recreate();
+    activityScenarioRule
+            .getScenario()
+            .onActivity(
+                    activity -> {
+                      assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED);
+                      assertThat(activity.getNumberOfRecreations()).isEqualTo(1);
+                    });
+  }
+
+  @Test
+  public void activityCanBeDestroyedManually() {
+    activityScenarioRule.getScenario().moveToState(Lifecycle.State.DESTROYED);
+  }
+
+  @SuppressWarnings("EmptyTryBlock")
+  @Test
+  public void ruleWithoutGetScenarioCallShouldNotThrow() {
+    try {
+
+    } catch(Throwable e) {
+      fail("ActivityScenarioRule should not throw an exception when used without calling getScenario()");
+    }
+  }
+
+  private static Stage lastLifeCycleTransition(Activity activity) {
+    return ActivityLifecycleMonitorRegistry.getInstance().getLifecycleStageOf(activity);
+  }
+}

--- a/ktx/ext/junit/java/androidx/test/ext/junit/rules/ActivityScenarioRule.kt
+++ b/ktx/ext/junit/java/androidx/test/ext/junit/rules/ActivityScenarioRule.kt
@@ -25,13 +25,18 @@ import android.os.Bundle
  * @param intent an intent to start activity or null to use the default one
  * @param activityOptions an activity options bundle to be passed along with the intent to start
  *        activity
+ * @param launchActivity true if the Activity should be launched automatically once per test. If
+ *                       set to false the launch of the activity under test will be deferred until
+ *                      {@link ActivityScenarioRule#getScenario()} is called.
+ *
  * @return ActivityScenarioRule which you can use to access to [ActivityScenario] from your tests
  */
 inline fun <reified A : Activity> activityScenarioRule(
   intent: Intent? = null,
-  activityOptions: Bundle? = null
+  activityOptions: Bundle? = null,
+  launchActivity: Boolean = true
 ):
 ActivityScenarioRule<A> = when (intent) {
-  null -> ActivityScenarioRule(A::class.java, activityOptions)
-  else -> ActivityScenarioRule(intent, activityOptions)
+  null -> ActivityScenarioRule(A::class.java, activityOptions, launchActivity)
+  else -> ActivityScenarioRule(intent, activityOptions, launchActivity)
 }

--- a/ktx/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithExplicitLaunchKotlinTest.kt
+++ b/ktx/ext/junit/javatests/androidx/test/ext/junit/rules/ActivityScenarioRuleWithExplicitLaunchKotlinTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.test.ext.junit.rules
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.testing.RecreationRecordingActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private fun lastLifeCycleTransition(activity: Activity): Stage {
+    return ActivityLifecycleMonitorRegistry.getInstance().getLifecycleStageOf(activity)
+}
+
+/**
+ * An example test with ActivityScenarioRule using Kotlin extensions.
+ */
+@RunWith(AndroidJUnit4::class)
+class ActivityScenarioRuleWithExplicitLaunchKotlinTest {
+    @get:Rule val activityScenarioRule = activityScenarioRule<RecreationRecordingActivity>(launchActivity = false)
+
+    @Test
+    fun activityShouldBeResumedAutomatically() {
+        activityScenarioRule
+                .scenario
+                .onActivity { activity: RecreationRecordingActivity ->
+                    assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED)
+                    assertThat(activity.numberOfRecreations).isEqualTo(0)
+                }
+    }
+
+    @Test
+    fun recreateActivityShouldWork() {
+        activityScenarioRule.scenario.recreate()
+        activityScenarioRule
+                .scenario
+                .onActivity { activity: RecreationRecordingActivity ->
+                    assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED)
+                    assertThat(activity.numberOfRecreations).isEqualTo(1)
+                }
+    }
+
+    @Test
+    fun activityCanBeDestroyedManually() {
+        activityScenarioRule.scenario.moveToState(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun ruleWithoutGetScenarioCallShouldNotThrow() {
+        try {
+        } catch (e: Throwable) {
+            Assert.fail("ActivityScenarioRule should not throw an exception when used without calling getScenario()")
+        }
+    }
+}


### PR DESCRIPTION
### Overview
This change makes it possible to defer the launch of the `Activity` under test until the first call to `ActivityScenarioRule.getScenario()`, so that different setups/options can be initialized before the test launches.

Fixes #446.

### Proposed Changes
*   Add two new constructors to `ActivityScenarioRule` that makes it possible to defer the launch of the `Activity` under test, with an API similar to `ActivityTestRule`
*   Refactor `activityScenarioRule()`-function to support the new launch mode. 

A "minor" remark regarding the tests:
I've not been able to figure out a way to run the tests I've created regarding the change to the `activityScenarioRule()`-function. Bazel just didn't want to sync the kotlin test files or in any way recognize my tests as tests.
So as an extra measure of certainty I brought the change into a project of mine and gave it a go there. All tests passed and additionally I was able to inject resources as mentioned in #446. 