### PR TITLE
Add LazyActivityScenarioRule that defers the launch of the Activity until needed

### DIFF
--- a/ext/junit/java/androidx/test/ext/junit/BUILD.bazel
+++ b/ext/junit/java/androidx/test/ext/junit/BUILD.bazel
@@ -16,6 +16,7 @@ android_library(
     deps = [
         "//:androidx_annotation",
         "//core",
+        "//espresso/core/java/androidx/test/espresso",
         "//runner/monitor",
         "@maven//:junit_junit",
     ],

--- a/ext/junit/java/androidx/test/ext/junit/rules/LazyActivityScenarioRule.java
+++ b/ext/junit/java/androidx/test/ext/junit/rules/LazyActivityScenarioRule.java
@@ -1,0 +1,191 @@
+package androidx.test.ext.junit.rules;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.EspressoException;
+
+import org.junit.rules.ExternalResource;
+
+import static androidx.test.internal.util.Checks.checkNotNull;
+
+/**
+ * Resembles {@link ActivityScenarioRule}, but instead of launching the Activity under test straight
+ * away, {@link LazyActivityScenarioRule} defers this until the first call to
+ * {@link LazyActivityScenarioRule#getScenario()}.
+ * <p>This can be used to initialize different setups/options before the test launches.</p>
+ *
+ * <p>Example:
+ *
+ * <pre>
+ *   &#64;Rule
+ *   public LazyActivityScenarioRule<MyActivity> rule = new LazyActivityScenarioRule<>(MyActivity.class);
+ *
+ *   &#64;Test
+ *   public void myTest() {
+ *     // Do initialization of your test setup here
+ *     // ie. populate an in-memory database, prepare test data, deactivate wifi etc.
+ *
+ *
+ *     // Launch the activity under test
+ *     ActivityScenario<MyActivity> scenario = rule.getScenario();
+ *     // Your test code goes here.
+ *   }
+ * </pre>
+ *
+ * <p>You can also explicitly disable the rule inside a specific test.
+ * <p>Example:
+ *
+ * <pre>
+ *   &#64;Rule
+ *   public LazyActivityScenarioRule<MyActivity> rule = new LazyActivityScenarioRule<>(MyActivity.class);
+ *
+ *   &#64;Test
+ *   public void myTest() {
+ *
+ *     rule.disable() // This disables the rule for a specific test
+ *     // Your test code goes here.
+ *   }
+ * </pre>
+ *
+ * @see ActivityScenarioRule
+ */
+public class LazyActivityScenarioRule<A extends Activity> extends ExternalResource {
+
+    /**
+     * Same as {@link java.util.function.Supplier} which requires API level 24.
+     *
+     * @hide
+     */
+    private interface Supplier<T> {
+        T get();
+    }
+
+    @NonNull
+    private final LazyActivityScenarioRule.Supplier<ActivityScenario<A>> scenarioSupplier;
+    @Nullable
+    private ActivityScenario<A> scenario;
+    private boolean disableRule = false;
+
+    /**
+     * Constructs {@link LazyActivityScenarioRule} for a given activity class.
+     *
+     * @param activityClass an activity class to launch
+     */
+    public LazyActivityScenarioRule(Class<A> activityClass) {
+        scenarioSupplier = () -> ActivityScenario.launch(checkNotNull(activityClass));
+    }
+
+    /**
+     * @see #LazyActivityScenarioRule(Class)
+     * @param activityOptions an activity options bundle to be passed along with the intent to start
+     *                        activity.
+     */
+    public LazyActivityScenarioRule(Class<A> activityClass, @Nullable Bundle activityOptions) {
+        scenarioSupplier = () -> ActivityScenario.launch(checkNotNull(activityClass), activityOptions);
+    }
+
+    /**
+     * Constructs {@link LazyActivityScenarioRule} with a given intent.
+     *
+     * @param startActivityIntent an intent to start an activity
+     */
+    public LazyActivityScenarioRule(Intent startActivityIntent) {
+        scenarioSupplier = () -> ActivityScenario.launch(checkNotNull(startActivityIntent));
+    }
+
+    /**
+     * @see #LazyActivityScenarioRule(Intent)
+     * @param activityOptions an activity options bundle to be passed along with the intent to start
+     *                        activity.
+     */
+    public LazyActivityScenarioRule(Intent startActivityIntent, @Nullable Bundle activityOptions) {
+        scenarioSupplier =
+                () -> ActivityScenario.launch(checkNotNull(startActivityIntent), activityOptions);
+    }
+
+    @Override
+    protected void after() {
+        if (disableRule) return;
+        if (scenario == null) {
+            throw new NoActivityLaunchedException(
+                    "No activities found. Did you remember to call getScenario() to " +
+                            "launch the activity under test.");
+        }
+        scenario.close();
+    }
+
+    /**
+     * Returns {@link ActivityScenario} of the given activity class.
+     *
+     * @throws DisableRuleException if you call this method after
+     * a {@link LazyActivityScenarioRule#disable()} call
+     * @throws NullPointerException if you call this method while test is not running
+     * @return a non-null {@link ActivityScenario} instance
+     */
+    @NonNull
+    public ActivityScenario<A> getScenario() {
+        if (disableRule) {
+            throw new DisableRuleException("Rule has been disabled. Calling getScenario() is not allowed.");
+        }
+        if (scenario == null) scenario = scenarioSupplier.get();
+        return checkNotNull(scenario);
+    }
+
+    /**
+     * If you have a test that doesn't need an Activity to run you can explicitly
+     * disable {@link LazyActivityScenarioRule} during a test.
+     *
+     * <p>Example:
+     *
+     * <pre>
+     *   &#64;Rule
+     *   public LazyActivityScenarioRule<MyActivity> rule = new LazyActivityScenarioRule<>(MyActivity.class);
+     *
+     *   &#64;Test
+     *   public void myTest() {
+     *
+     *     rule.disable() // This disables the rule for a specific test
+     *     // Your test code goes here.
+     *   }
+     * </pre>
+     *
+     * @throws DisableRuleException if called multiple times or if called
+     * after {@link LazyActivityScenarioRule#getScenario()}
+     */
+    public void disable() {
+        if (scenario != null) {
+            throw new DisableRuleException(
+                    "It's not possible to disable the rule after getScenario() has been called.");
+        }
+        if (disableRule) {
+            throw new DisableRuleException("Multiple calls to disable() is not allowed.");
+        }
+        disableRule = true;
+    }
+
+    /** An exception which indicates that no activity has been launched. */
+    public static final class NoActivityLaunchedException extends IllegalStateException
+            implements EspressoException {
+
+        public NoActivityLaunchedException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * An exception which indicates an illegal state regarding the
+     * use of {@link LazyActivityScenarioRule#disable()}.
+     * */
+    public static final class DisableRuleException extends IllegalStateException
+            implements EspressoException {
+
+        public DisableRuleException(String message) {
+            super(message);
+        }
+    }
+}

--- a/ext/junit/javatests/androidx/test/ext/junit/rules/LazyActivityScenarioRuleTest.java
+++ b/ext/junit/javatests/androidx/test/ext/junit/rules/LazyActivityScenarioRuleTest.java
@@ -1,0 +1,94 @@
+package androidx.test.ext.junit.rules;
+
+import android.app.Activity;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.testing.RecreationRecordingActivity;
+import androidx.test.ext.junit.rules.LazyActivityScenarioRule.DisableRuleException;
+import androidx.test.ext.junit.rules.LazyActivityScenarioRule.NoActivityLaunchedException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Tests for {@link LazyActivityScenarioRule} */
+@RunWith(AndroidJUnit4.class)
+public final class LazyActivityScenarioRuleTest {
+
+  @Rule
+  public LazyActivityScenarioRule<RecreationRecordingActivity> activityScenarioRule =
+          new LazyActivityScenarioRule<>(RecreationRecordingActivity.class, null);
+
+  // TODO: Refactor tests to use assertThrows when JUnit is updated to version 4.13
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void activityShouldBeResumedAutomatically() {
+    activityScenarioRule
+            .getScenario()
+            .onActivity(
+                    activity -> {
+                      assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED);
+                      assertThat(activity.getNumberOfRecreations()).isEqualTo(0);
+                    });
+  }
+
+  @Test
+  public void recreateActivityShouldWork() {
+    activityScenarioRule.getScenario().recreate();
+    activityScenarioRule
+            .getScenario()
+            .onActivity(
+                    activity -> {
+                      assertThat(lastLifeCycleTransition(activity)).isEqualTo(Stage.RESUMED);
+                      assertThat(activity.getNumberOfRecreations()).isEqualTo(1);
+                    });
+  }
+
+  @Test
+  public void activityCanBeDestroyedManually() {
+    activityScenarioRule.getScenario().moveToState(Lifecycle.State.DESTROYED);
+  }
+
+  @Test
+  public void whenNoGetScenarioCall_ShouldThrowNoActivityLaunchedException() {
+    expectedException.expect(NoActivityLaunchedException.class);
+    expectedException.expectMessage("No activities found. Did you remember to call getScenario() to " +
+            "launch the activity under test.");
+  }
+
+  @Test
+  public void whenDisabledGetScenarioCall_ShouldThrowDisableRuleException() {
+    expectedException.expect(DisableRuleException.class);
+    expectedException.expectMessage("Rule has been disabled. Calling getScenario() is not allowed.");
+    activityScenarioRule.disable();
+    activityScenarioRule.getScenario();
+  }
+
+  @Test
+  public void whenGetScenarioCalledDisable_ShouldThrowDisableRuleException() {
+    expectedException.expect(DisableRuleException.class);
+    expectedException.expectMessage("It's not possible to disable the rule after getScenario() has been called.");
+    activityScenarioRule.getScenario();
+    activityScenarioRule.disable();
+  }
+
+  @Test
+  public void whenDisabledCalledTwice_ShouldThrowDisableRuleException() {
+    expectedException.expect(DisableRuleException.class);
+    expectedException.expectMessage("Multiple calls to disable() is not allowed.");
+    activityScenarioRule.disable();
+    activityScenarioRule.disable();
+  }
+
+  private static Stage lastLifeCycleTransition(Activity activity) {
+    return ActivityLifecycleMonitorRegistry.getInstance().getLifecycleStageOf(activity);
+  }
+}


### PR DESCRIPTION
### Overview

This change makes it possible to defer the launch of the `Activity` under test until the first call to `LazyActivityScenarioRule.getScenario()`, so that different setups/options can be initialized before the `Activity` is launched.

Fixes #446.

### Proposed Changes

- Add `LazyActivityScenarioRule` (similar to `ActivityScenarioRule`) that instead of launching the `Activity` under test right away, defers this until the first call to `LazyActivityScenarioRule.getScenario()`. This makes it possible to initialize different setups ie. populate an in-memory database, prepare test data, deactivate wifi etc.
- Add the possibility to `disable()` the new `Rule` in tests that doesn't need an `Activity` to run, ie. tests for:
  - internal utility-methods
  - internal test data generators etc.