### PR TITLE
Add testonly attribute to testonly targets.

### DIFF
--- a/ktx/core/javatests/androidx/test/core/app/BUILD.bazel
+++ b/ktx/core/javatests/androidx/test/core/app/BUILD.bazel
@@ -38,6 +38,7 @@ kt_android_library(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
+    testonly = 1,
 )
 
 android_binary(

--- a/ktx/ext/junit/javatests/androidx/test/ext/junit/rules/BUILD.bazel
+++ b/ktx/ext/junit/javatests/androidx/test/ext/junit/rules/BUILD.bazel
@@ -40,6 +40,7 @@ kt_android_library(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
+    testonly = 1,
 )
 
 android_local_test(
@@ -113,6 +114,7 @@ kt_android_library(
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],
+    testonly = 1,
 )
 
 


### PR DESCRIPTION
### Overview
Removes several build errors.

Closes #887.

### Proposed Changes
Add testonly attribute to testonly targets.

### Sidenote

With my extremely limited knowledge of bazel this looks like a bug with: 
```bazel
package(
    default_testonly = 1,
)
```
Should probably be reported upstream in the bazel.