### PR TITLE
Run futurize on py2 code

### DIFF
--- a/tools/android/emulator/emulated_device.py
+++ b/tools/android/emulator/emulated_device.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Classes to interact with android emulator."""
+from __future__ import print_function
 
 
 
@@ -1999,7 +2000,7 @@ class EmulatedDevice(object):
 
       if self.delete_temp_on_exit and self._emulator_tmp_dir:
         logging.info('Cleaning up data dirs.')
-        print 'cleanup data dirs...'
+        print('cleanup data dirs...')
         self.CleanUp()
         logging.info('Clean up done.')
 
@@ -3523,8 +3524,7 @@ class EmulatedDevice(object):
 
   def GetApiCodeName(self):
     """Returns the codename of the image if it exists in source.properties."""
-    if self._source_properties and self._source_properties.has_key(
-        API_CODE_NAME):
+    if self._source_properties and API_CODE_NAME in self._source_properties:
       return self._source_properties[API_CODE_NAME]
     return ''
 

--- a/tools/android/emulator/emulated_device_software_open_gl_integration_test.py
+++ b/tools/android/emulator/emulated_device_software_open_gl_integration_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Large tests which actually starts an emulator."""
+from __future__ import print_function
 
 
 
@@ -83,7 +84,7 @@ class EmulatedDeviceSoftwareOpenGlIntegrationTest(googletest.TestCase):
 
     # Vals for this flag: -1 not an emulator, 0 emulator which doesn't support
     # open gl, 1 emulator which supports opengl.
-    print get_prop_output
+    print(get_prop_output)
     self.assertTrue('[ro.kernel.qemu.gles]: [1]' in get_prop_output)
 
 if __name__ == '__main__':

--- a/tools/android/emulator/unified_launcher.py
+++ b/tools/android/emulator/unified_launcher.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Allows emulators to be booted ran/killed."""
+from __future__ import print_function
 
 
 
@@ -465,25 +466,25 @@ def _RestartDevice(device,
 
   if 'x86' == proto.emulator_architecture:
     if not _IsKvmPresent():
-      print ''
-      print '=' * 80
+      print('')
+      print('=' * 80)
       print ('= By activating KVM on your local host you can increase the '
              'speed of the emulator.      =')
-      print '=' * 80
+      print('=' * 80)
     elif not proto.with_kvm:
-      print ''
-      print '=' * 80
+      print('')
+      print('=' * 80)
       print ('= Please add --no to your bazel command line, to create '
              'snapshot images   =')
       print ('= local with KVM support. This will increase the speed of the '
              'emulator.        =')
-      print '=' * 80
+      print('=' * 80)
   else:
-    print ''
-    print '=' * 80
+    print('')
+    print('=' * 80)
     print ('= By using x86 with KVM on your local host you can increase the '
            'speed of the emulator.')
-    print '=' * 80
+    print('=' * 80)
 
   proto.system_image_dir = system_images_dir
   sysimg = (
@@ -1060,9 +1061,9 @@ def _IsKvmPresent():
   kernel_module = os.access('/sys/class/misc/kvm/dev', os.R_OK)
   device_node = os.access(kvm_device, os.R_OK | os.W_OK)
   if not kernel_module:
-    print 'KVM Kernel module not readable.'
+    print('KVM Kernel module not readable.')
   if not device_node:
-    print '%s: not readable or writable by current user' % kvm_device
+    print('%s: not readable or writable by current user' % kvm_device)
 
   return device_node and kernel_module
 

--- a/tools/android/emulator/xres.py
+++ b/tools/android/emulator/xres.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Simply prints out screen resolution."""
+from __future__ import print_function
 
 
 import Tkinter
@@ -20,7 +21,7 @@ import Tkinter
 
 def main():
   root = Tkinter.Tk()
-  print '%sx%s' % (root.winfo_screenwidth(), root.winfo_screenheight())
+  print('%sx%s' % (root.winfo_screenwidth(), root.winfo_screenheight()))
   root.destroy()
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Overview
Basic futurizing py2 code for emulator launcher

### Proposed Changes
In order to make the bazel emulator launcher compatible with Python2 and Python3, I ran https://python-future.org