### PR TITLE
Always print instrumentation time in US locale

### DIFF
--- a/runner/android_junit_runner/java/androidx/test/internal/runner/listener/InstrumentationResultPrinter.java
+++ b/runner/android_junit_runner/java/androidx/test/internal/runner/listener/InstrumentationResultPrinter.java
@@ -21,7 +21,6 @@ import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 import androidx.test.services.events.internal.StackTrimmer;
 import java.io.PrintStream;
-import org.junit.internal.TextListener;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -223,6 +222,6 @@ public class InstrumentationResultPrinter extends InstrumentationRunListener {
   public void instrumentationRunFinished(
       PrintStream streamResult, Bundle resultBundle, Result junitResults) {
     // reuse JUnit TextListener to display a summary of the run
-    new TextListener(streamResult).testRunFinished(junitResults);
+    new TestSummaryListener(streamResult).testRunFinished(junitResults);
   }
 }

--- a/runner/android_junit_runner/java/androidx/test/internal/runner/listener/TestSummaryListener.java
+++ b/runner/android_junit_runner/java/androidx/test/internal/runner/listener/TestSummaryListener.java
@@ -1,0 +1,23 @@
+package androidx.test.internal.runner.listener;
+
+import org.junit.internal.TextListener;
+
+import java.io.PrintStream;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * A {@link org.junit.runner.notification.RunListener} for printing a test summary at the end of an
+ * instrumentation run.
+ */
+public class TestSummaryListener extends TextListener {
+    public TestSummaryListener(PrintStream writer) {
+        super(writer);
+    }
+
+    @Override
+    protected String elapsedTimeAsString(long runTime) {
+        // Use Locale.US so that instrumentation parsers can parse it correctly.
+        return NumberFormat.getInstance(Locale.US).format((double) runTime / 1000);
+    }
+}

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/listeners/TextListener.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/listeners/TextListener.java
@@ -20,6 +20,7 @@ import androidx.test.orchestrator.junit.ParcelableFailure;
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Reimplementation of org.junit.TextListener that accepts {@link
@@ -115,6 +116,7 @@ public class TextListener
 
   /** Returns the formatted string of the elapsed time. Duplicated from BaseTestRunner. Fix it. */
   protected String elapsedTimeAsString(long runTime) {
-    return NumberFormat.getInstance().format((double) runTime / 1000);
+    // Use Locale.US so that instrumentation parsers can parse it correctly.
+    return NumberFormat.getInstance(Locale.US).format((double) runTime / 1000);
   }
 }


### PR DESCRIPTION
Instead of using the default locale, always print the "Time: " output in US locale. This fixes an issue where changing the device locale affects the format of the line and causes the instrumentation output parser in ddmlib to be unable to parse the time.

For example, if you set the device to use the Arabic locale, you currently get:

    Time: ٣٫٦٤١