### PR TITLE
Add resume mode for orchestrator runner

### DIFF
--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/OrchestratorConstants.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/OrchestratorConstants.java
@@ -20,6 +20,7 @@ final class OrchestratorConstants {
 
   static final String TARGET_INSTRUMENTATION_ARGUMENT = "targetInstrumentation";
   static final String ISOLATED_ARGUMENT = "isolated";
+  static final String RESUME_ARGUMENT = "resume";
   static final String ORCHESTRATOR_DEBUG_ARGUMENT = "orchestratorDebug";
   static final String COVERAGE_FILE_PATH = "coverageFilePath";
   static final String CLEAR_PKG_DATA = "clearPackageData";

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/listeners/OrchestrationResultPrinter.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/listeners/OrchestrationResultPrinter.java
@@ -18,6 +18,8 @@ package androidx.test.orchestrator.listeners;
 import android.app.Instrumentation;
 import android.os.Bundle;
 import android.util.Log;
+
+import androidx.test.orchestrator.AndroidTestOrchestrator;
 import androidx.test.orchestrator.junit.ParcelableDescription;
 import androidx.test.orchestrator.junit.ParcelableFailure;
 import java.io.PrintStream;
@@ -138,6 +140,14 @@ public class OrchestrationResultPrinter extends OrchestrationRunListener {
     if (testResultCode == REPORT_VALUE_RESULT_OK) {
       testResult.putString(Instrumentation.REPORT_KEY_STREAMRESULT, ".");
     }
+
+    Instrumentation instrumentation = this.getInstrumentation();
+
+    if (instrumentation instanceof AndroidTestOrchestrator) {
+      String test = description.getClassName() + "#" + description.getMethodName();
+      ((AndroidTestOrchestrator) instrumentation).removeFinishedTests(test);
+    }
+
     sendStatus(testResultCode, testResult);
   }
 


### PR DESCRIPTION
Start a new instrument process only when test process crashed 

Default behaviour:
case 1 → process 1
    ↓
clear app data
    ↓
case 2 → process 2 (crash)
    ↓
clear app data
    ↓
case 3 → process 3
    ...

New behaviour:
case 1 → process 1
    ↓
case 2 → process 1 (crash)
    ↓
case 3 → process 2
    ...

Specifying instrument argument `resume=true` to trigger.

e.g. `./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.resume=true`