### PR TITLE
Fix no tests found issue when using @Parameters name

### DIFF
--- a/runner/android_junit_runner/java/androidx/test/internal/runner/TestRequestBuilder.java
+++ b/runner/android_junit_runner/java/androidx/test/internal/runner/TestRequestBuilder.java
@@ -482,7 +482,7 @@ public class TestRequestBuilder {
 
     // Strips out the parameterized suffix if it exists
     private String stripParameterizedSuffix(String name) {
-      Pattern suffixPattern = Pattern.compile(".+(\\[[0-9]+\\])$");
+      Pattern suffixPattern = Pattern.compile(".+(\\[.+\\])$");
       if (suffixPattern.matcher(name).matches()) {
         name = name.substring(0, name.lastIndexOf('['));
       }


### PR DESCRIPTION
When test is using `@RunWith(Parameterized.class)` and specify parameter name `Parameters(name = "{index}:Foo")`

Test runner cannot find any tests due to the regex pattern limitation.