### PR TITLE
Bump Robolectric to 4.7

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,7 +135,7 @@ maven_install(
         "org.mockito:mockito-core:2.25.0",
         "org.objenesis:objenesis:2.1",
         "org.pantsbuild:jarjar:1.7.2",
-        "org.robolectric:robolectric:4.6.1",
+        "org.robolectric:robolectric:4.7.2",
     ],
     repositories = [
         "https://maven.google.com",

--- a/repo.bzl
+++ b/repo.bzl
@@ -18,8 +18,8 @@ def _development_repositories():
 
     http_archive(
         name = "robolectric",
-        strip_prefix = "robolectric-bazel-4.6.1",
-        urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.6.1.tar.gz"],
+        strip_prefix = "robolectric-bazel-4.7.2",
+        urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.7.2.tar.gz"],
     )
     # uncomment to test with new robolectric version. Change path to point to local filesystem
     # clone of https://github.com/robolectric/robolectric-bazel


### PR DESCRIPTION
Robolectric 4.7.2 is the latest stable release of Robolectric 4.7.x.

cc @hoisie @brettchabot .