### PR TITLE
Bump Robolectric to 4.8.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,7 +135,7 @@ maven_install(
         "org.mockito:mockito-core:2.28.1",
         "org.objenesis:objenesis:2.6",
         "org.pantsbuild:jarjar:1.7.2",
-        "org.robolectric:robolectric:4.7.3",
+        "org.robolectric:robolectric:4.8.1",
     ],
     repositories = [
         "https://maven.google.com",

--- a/repo.bzl
+++ b/repo.bzl
@@ -18,8 +18,8 @@ def _development_repositories():
 
     http_archive(
         name = "robolectric",
-        strip_prefix = "robolectric-bazel-4.7.3",
-        urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.7.3.tar.gz"],
+        strip_prefix = "robolectric-bazel-4.8.1",
+        urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.8.1.tar.gz"],
     )
     # uncomment to test with new robolectric version. Change path to point to local filesystem
     # clone of https://github.com/robolectric/robolectric-bazel


### PR DESCRIPTION
See https://github.com/robolectric/robolectric/releases/tag/robolectric-4.8.1 and https://github.com/robolectric/robolectric-bazel/releases/tag/4.8.1.  /cc @hoisie @brettchabot .