### PR TITLE
Bump rules_jvm_external to 4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bazel-*
 # Intellij IDEA
 .idea
 .gradle
+.ijwb

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,9 @@ workspace(name = "android_test_support")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-RULES_JVM_EXTERNAL_TAG = "4.4.2"
+RULES_JVM_EXTERNAL_TAG = "4.5"
 
-RULES_JVM_EXTERNAL_SHA = "735602f50813eb2ea93ca3f5e43b1959bd80b213b836a07a62a29d757670b77b"
+RULES_JVM_EXTERNAL_SHA = "b17d7388feb9bfa7f2fa09031b32707df529f26c91ab9e5d909eb1676badd9a6"
 
 # This needs to be consistent with the KOTLIN_VERSION specified in build_extensions/axt_versions.bzl.
 KOTLIN_VERSION = "1.7.22"


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_jvm_external/releases/tag/4.5.