### PR TITLE
Switch to 33.0.2 build tools in bazel.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,7 +194,7 @@ maven_install(
 android_sdk_repository(
     name = "androidsdk",
     api_level = 33,
-    build_tools_version = "30.0.3",
+    build_tools_version = "33.0.2",
 )
 
 load("//:repo.bzl", "android_test_repositories")

--- a/build_extensions/BUILD
+++ b/build_extensions/BUILD
@@ -11,4 +11,5 @@ exports_files([
     "AndroidManifest_instrumentation_test_template.xml",
     "AndroidManifest_robolectric.xml",
     "robolectric.properties",
+    "mainDexClasses.rules",
 ])

--- a/build_extensions/mainDexClasses.rules
+++ b/build_extensions/mainDexClasses.rules
@@ -1,0 +1,20 @@
+  -keep public class * extends android.app.Instrumentation {
+    <init>();
+  }
+  -keep public class * extends android.app.Application {
+    <init>();
+    void attachBaseContext(android.content.Context);
+  }
+  -keep public class * extends android.app.backup.BackupAgent {
+   <init>();
+  }
+# We need to keep all annotation classes because proguard does not trace annotation attribute
+# it just filter the annotation attributes according to annotation classes it already kept.
+  -keep public class * extends java.lang.annotation.Annotation {
+   *;
+  }
+# Keep old fashion tests in the main dex or they'll be silently ignored by InstrumentationTestRunner
+  -keep public class * extends android.test.InstrumentationTestCase {
+   <init>();
+  }
+

--- a/services/BUILD
+++ b/services/BUILD
@@ -33,6 +33,7 @@ android_binary(
     visibility = [
         "//visibility:public",
     ],
+    main_dex_proguard_specs = ["//build_extensions:mainDexClasses.rules"],
     deps = [
         "//services/shellexecutor:exec_server",
         "//services/speakeasy/java/androidx/test/services/speakeasy:protocol",


### PR DESCRIPTION
This required copying the mainDexClasses rules from build tools 32, since build tools 33 no longer has that file.

Bug: 273280280

