### PR TITLE
Refresh README and CONTRIBUTING docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ again.
 
 AndroidX Test uses the [Bazel](https://bazel.build) build system.
 
-Currently only Linux is fully supported. For Mac and windows users, you may be able to build
-and run the Robolectric tests.
+Currently only Linux is fully supported. Mac may work but is not regularly tested
 
 ### One time setup
 
@@ -28,16 +27,13 @@ and run the Robolectric tests.
     [clone](https://help.github.com/articles/cloning-a-repository/) the
     [AndroidX Test repo](https://github.com/android/android-test)
 *   Install [Bazelisk](https://github.com/bazelbuild/bazelisk/blob/master/README.md)
-    For instrumentation testing on Linux make sure your environment
-    meets the following
-    [prerequisites](https://docs.bazel.build/versions/master/android-instrumentation-test.html#prerequisites)
-    However note that instrumentation test execution support is currently not setup
+    Note that instrumentation test execution support is currently not setup
     for androidx test libraries.
 *   Install [maven](http://maven.apache.org/install.html) and make it available
     on PATH.
 *   Install the [Android SDK](https://developer.android.com/studio/install) and
     run the following command to ensure you have the necessary components:
-    `./tools/bin/sdkmanager --install 'build-tools;30.0.3'
+    `./tools/bin/sdkmanager --install 'build-tools;33.0.2'
     'platforms;android-33' 'emulator' 'platform-tools'
 *   Set the `ANDROID_HOME` environment variable to point to the SDK install
     location. For example
@@ -75,12 +71,12 @@ bazelisk build :axt_m2repository
 ### Testing
 
 ```
-bazelisk test <target path> --spawn_strategy=local
+bazelisk test <target path> 
 ```
 
 e.g. to run the androidx-test-core tests:
 ```
-bazelisk test //core/javatests/... --spawn_strategy=local --host_force_python=PY2
+bazelisk test //core/javatests/... 
 ```
 
 To run all the robolectric local tests (and thus replicate the GitHub CI):
@@ -107,8 +103,8 @@ If your project fails to build because of unresolved imports two things might be
     ```bazel
     android_sdk_repository(
         ...
-        api_level = 30,
-        build_tools_version = "30.0.2",
+        api_level = 33,
+        build_tools_version = "33.0.2",
         ...
     )
     ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
-# AndroidX Test Library
+This GitHub project hosts two somewhat distinct projects: 
+1. AndroidX Test libraries
+2. Bazel support for android_instrumentation_test
+
+# AndroidX Test Libraries
 
 The AndroidX Test Library provides an extensive framework for testing Android apps. This library provides a set of APIs that allow you to quickly build and run test code for your apps, including JUnit 4 and functional user interface (UI) tests. You can run tests created using these APIs from the Android Studio IDE or from the command line.
 
 For more details see [developers.android.com/testing](https://developers.android.com/testing)
+
+The following maven libraries are hosted in this repo:
+
+androidx.test:annotation
+androidx.test:core
+androidx.test.espresso*
+androidx.test.ext:junit
+androidx.test:orchestrator
+androidx.test:runner
+androidx.test:rules
+androidx.test:services
+
+androidx.test.uiautomator and androidx.test:ext:junit-gtest are hosted on [AOSP](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/README.md)
 
 ## Contributing
 
@@ -19,7 +36,12 @@ Please see the
 for general questions and discussion, and please direct specific questions to
 [Stack Overflow](https://stackoverflow.com/questions/tagged/androidx-test).
 
-## Bazel integration
+## Releases
+
+https://developer.android.com/jetpack/androidx/releases/test is the canonical source for release notes, and
+https://maven.google.com for release artifacts and source snapshots.
+
+# Bazel android_instrumentation_test support 
 
 To depend on this repository in Bazel, add the following snippet to your
 WORKSPACE file:
@@ -36,9 +58,3 @@ load("@android_test_support//:repo.bzl", "android_test_repositories")
 android_test_repositories()
 ```
 
-## Releases
-
-Androidx.test no longer uses github to track releases.
-
-See https://developer.android.com/jetpack/androidx/releases/test for release notes, and
-https://maven.google.com for release artifacts and source snapshots.


### PR DESCRIPTION
- Add more info on what projects are hosted on this repo
- Update release info now that github is used to tag releases again
- Remove mention of android instrumentation test execution for androidx.test libraries
- Update to mention build tools 33.0.2

