### PR TITLE
Experiment with not using gradle cache in gradle-emulator-test GitHub…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
             echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
             sudo udevadm control --reload-rules
             sudo udevadm trigger --name-match=kvm       
-      - name: 'Cache Gradle files'
-        uses: gradle/gradle-build-action@v2
+            #    - name: 'Cache Gradle files'
+            #uses: gradle/gradle-build-action@v2
       - name: 'Download local snapshot for tests'
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
… Action.

gradle-emulator-test started failing when the runner version was changed in #1889 (https://github.com/android/android-test/actions/runs/5904773196/job/16017633837), which seems to indicate gradle-emulator-test  is not properly using the artifacts at head.

### Overview

### Proposed Changes
