### PR TITLE
Clone the gradle emulator tests to run on mac too.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,41 @@ jobs:
         with:
           name: test-reports
           path: gradle-tests/**/build/reports/androidTests/
+  gradle-emulator-test_mac:
+    runs-on: macos-latest
+    needs: build
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: 'Cache Gradle files'
+        uses: gradle/gradle-build-action@v2
+      - name: 'Download local snapshot for tests'
+        uses: actions/download-artifact@v3
+        with:
+          name: local-snapshot
+          path: ~/download
+      - name: 'Install to local maven repo'
+        run: |
+          mkdir -p ~/.m2
+          unzip ~/download/axt_m2repository.zip -d ~/.m2/
+        shell: bash
+      - name: 'Setup Android SDK'
+        uses: android-actions/setup-android@v2
+      - name: 'Run gradle tests'
+        run: |
+          cd ${{ github.workspace }}/gradle-tests
+          ./gradlew nexusOneApi30DebugAndroidTest -Dorg.gradle.workers.max=1 -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true --info
+        shell: bash
+      - name: 'Upload test reports'
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: gradle-tests/**/build/reports/androidTests/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,4 @@ jobs:
           name: test-reports
           path: gradle-tests/**/build/reports/androidTests/
 
+


### PR DESCRIPTION
The idea is to gauge reliablity of GMD+free tier GitHub actions


