### PR TITLE
Fix ATO crashing when output filename exceeds 255 character limit

### DIFF
--- a/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/AndroidTestOrchestratorTest.java
+++ b/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/AndroidTestOrchestratorTest.java
@@ -16,7 +16,9 @@
 package androidx.test.orchestrator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
@@ -43,5 +45,45 @@ public class AndroidTestOrchestratorTest {
   public void testSingleMethodTest_blankInput() {
     assertThat(AndroidTestOrchestrator.isSingleMethodTest(null), is(false));
     assertThat(AndroidTestOrchestrator.isSingleMethodTest(""), is(false));
+  }
+
+  @Test
+  public void testMakeValidFilename_notTooLong() {
+    final int maxLength = 20;
+
+    assertThat(
+        // len("hello_world") = 11, with ".txt" appended it's still way below maxLength
+        AndroidTestOrchestrator.makeValidFilename("hello_world", maxLength), is("hello_world.txt"));
+  }
+
+  @Test
+  public void testMakeValidFilename_equalToMaxLength() {
+    final int maxLength = 20;
+
+    assertThat(
+        // len("hello_world_abcd") = 16, with ".txt" appended it's equal to maxLength
+        AndroidTestOrchestrator.makeValidFilename("hello_world_abcd", maxLength),
+        is("hello_world_abcd.txt"));
+  }
+
+  @Test
+  public void testMakeValidFilename_differrentWhenTooLong() {
+    final int maxLength = 20;
+
+    // len() of both of these is 18, with ".txt" appended they exceed maxLength
+    String filename1 = AndroidTestOrchestrator.makeValidFilename("hello_world_abcdef", maxLength);
+    String filename2 = AndroidTestOrchestrator.makeValidFilename("hello_world_ghijkl", maxLength);
+    assertThat(filename1, is(not(equalTo(filename2))));
+  }
+
+  @Test
+  public void testMakeValidFilename_tooLong() {
+    final int maxLength = 20;
+
+    assertThat(
+        // len("hello_world_abcde") is 17, with ".txt" appended it exceeds maxLength
+        AndroidTestOrchestrator.makeValidFilename("hello_world_abcde", maxLength),
+        // hash code of "hello_world_abcde" is "889cc989"
+        is("hello_wo889cc989.txt"));
   }
 }


### PR DESCRIPTION
Fixes #1935