### PR TITLE
Restore the -Dorg.gradle.workers.max=1 flag in gradle-emulator-test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: 'Run gradle tests'
         run: |
           cd ${{ github.workspace }}/gradle-tests
-          ./gradlew nexusOneDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" --no-watch-fs --info
+          ./gradlew nexusOneDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Dorg.gradle.workers.max=1 --no-watch-fs --info
         shell: bash
       - name: 'Upload test reports'
         if: success() || failure()


### PR DESCRIPTION
Commit 5fcf70a6f3cff9d2593940a40be57bef00692595  removed the -Dorg.gradle.workers.max=1 flag in an attempt to speed up the job. Unfortunately it looks like the ob is ~30% flaky on github actions without this flag.
