### PR TITLE
Setup gradle managed device in a separate step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,14 @@ jobs:
         shell: bash
       - name: 'Setup Android SDK'
         uses: android-actions/setup-android@v2
+      - name: 'Setup gradle managed device'
+        run: |
+          cd ${{ github.workspace }}/gradle-tests
+          ./gradlew runner:nexusOneSetup -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" --no-watch-fs --info
       - name: 'Run gradle tests'
         run: |
           cd ${{ github.workspace }}/gradle-tests
-          ./gradlew nexusOneDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Dorg.gradle.workers.max=1 --no-watch-fs --info
+          ./gradlew nexusOneDebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" --no-watch-fs --info
         shell: bash
       - name: 'Upload test reports'
         if: success() || failure()


### PR DESCRIPTION
Setup the snapshot in a separate step so it can be cached. The hope is this will allow removal of the org.gradle.workers.max=1 limitation when performing the gradle build.


