### PR TITLE
Bump Robolectric to 4.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install Java 11
+      - name: Install Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: 'Cache Bazel files'
         uses: actions/cache@v3
         with:
@@ -63,11 +63,11 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install Java 11
+      - name: Install Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: 'Cache Bazel files'
         uses: actions/cache@v3
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -179,7 +179,7 @@ maven_install(
                 ),
             ],
             group = "org.robolectric",
-            version = "4.10.3",
+            version = "4.11.1",
         ),
     ],
     fetch_sources = True,

--- a/build_extensions/robolectric.properties
+++ b/build_extensions/robolectric.properties
@@ -1,4 +1,4 @@
-# Use SDK 33 by default
-sdk=33
+# Use SDK 34 by default
+sdk=34
 # make Robolectric match the emulator used
 qualifiers=w480dp-h800dp

--- a/repo.bzl
+++ b/repo.bzl
@@ -18,9 +18,9 @@ def _development_repositories():
 
     http_archive(
         name = "robolectric",
-        strip_prefix = "robolectric-bazel-4.10.3",
-        sha256 = "1b199a932cbde4af728dd8275937091adbb89a4bf63d326de49e6d0a42e723bf",
-        urls = ["https://github.com/robolectric/robolectric-bazel/archive/refs/tags/4.10.3.tar.gz"],
+        strip_prefix = "robolectric-bazel-4.11.1",
+        sha256 = "1ea1cfe67848decf959316e80dd69af2bbaa359ae2195efe1366cbdf3e968356",
+        urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/4.11.1/robolectric-bazel-4.11.1.tar.gz"],
     )
     # uncomment to test with new robolectric version. Change path to point to local filesystem
     # clone of https://github.com/robolectric/robolectric-bazel


### PR DESCRIPTION
See https://github.com/robolectric/robolectric-bazel/releases/tag/4.11.1.

Although robolectric-bazel 4.11.1 recommends using rules_jvm_external 5.3, but this repository needs to keep using 4.5 until there is solution to fix the following error with latest rules_jvm_external:

```
 ERROR: /home/runner/work/android-test/android-test/annotation/java/androidx/test/annotation/BUILD:38:15: in maven_artifact rule //annotation/java/androidx/test/annotation:annotation_maven_artifact: 
Traceback (most recent call last):
	File "/home/runner/work/android-test/android-test/build_extensions/maven/maven_artifact.bzl", line 219, column 37, in _maven_artifact_impl
		pom_content = _create_pom_string(ctx, group_id, artifact_id, version, packaging_type, maven_deps, ctx.attr.excluded_dependencies)
	File "/home/runner/work/android-test/android-test/build_extensions/maven/maven_artifact.bzl", line 104, column 80, in _create_pom_string
		dep_group_id, dep_artifact_id, dep_version = _parse_artifact_versioning(dep)
	File "/home/runner/work/android-test/android-test/build_extensions/maven/maven_artifact.bzl", line 161, column 13, in _parse_artifact_versioning
		fail("artifact_deps values must be of form: groupId:artifactId:version. Found %s" % artifact_coordinates)
Error in fail: artifact_deps values must be of form: groupId:artifactId:version. Found androidx.annotation:annotation-experimental:aar:1.1.0
ERROR: /home/runner/work/android-test/android-test/annotation/java/androidx/test/annotation/BUILD:38:15: Analysis of target '//annotation/java/androidx/test/annotation:annotation_maven_artifact' failed
ERROR: Analysis of target '//:axt_m2repository' failed; build aborted: 
```