### PR TITLE
Fix building maven artifacts on mac.

### DIFF
--- a/build_extensions/maven/maven_artifact.sh
+++ b/build_extensions/maven/maven_artifact.sh
@@ -63,7 +63,7 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters in case we need that
 
-out_tmp="$(mktemp -d --suffix=_repo)"
+out_tmp="$(mktemp -d )"
 dirname="repository"
 repo="$out_tmp/$dirname"
 


### PR DESCRIPTION
The maven artifact generation script used 'mktemp --suffix' which is apparently not available on mac. This commit just removes the '--suffix' argument since it is not strictly necessary.

Fixes #734


