### PR TITLE
Switch back to default github runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
   build:
-    runs-on:
-      group: Large Runners
+    runs-on: ubuntu-latest
     needs: gradle-wrapper-validation
     timeout-minutes: 20
     steps:
@@ -64,8 +63,7 @@ jobs:
           rm -rf ~/.cache/bazel/*/*/external/
         shell: bash
   test:
-    runs-on:
-      group: Large Runners
+    runs-on: ubuntu-latest
     needs: gradle-wrapper-validation
     timeout-minutes: 20
     steps:
@@ -97,8 +95,7 @@ jobs:
           rm -rf ~/.cache/bazel/*/*/external/
         shell: bash
   gradle-emulator-test:
-    runs-on:
-      group: Large Runners
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
The default Linux runner are now 4 core/16 GB RAM with KVM: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/


