### PR TITLE
CI: make gradle-wrapper-validation a prereq only in gradle tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
   build:
     runs-on: ubuntu-latest
-    needs: gradle-wrapper-validation
     timeout-minutes: 20
     steps:
       - name: Check out repository code
@@ -64,7 +63,6 @@ jobs:
         shell: bash
   test:
     runs-on: ubuntu-latest
-    needs: gradle-wrapper-validation
     timeout-minutes: 20
     steps:
       - name: Check out repository code
@@ -96,7 +94,7 @@ jobs:
         shell: bash
   gradle-emulator-test:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, gradle-wrapper-validation]
     timeout-minutes: 20
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Previously the gradle-wrapper-validation task was a prerequisite for the build and test actions, which doesn't make sense since those actions do not use gradle.

Instead, make gradle-wrapper-validation a prerequisite only for the gradle-emulator-tests action. This should speed up CI latency by a few seconds, since now gradle-wrapper-validation can run in parallel.

