### PR TITLE
Consider adding a setter to ApplicationInfoBuilder.flags

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 **API Changes**
 
+* Added ApplicationInfoBuilder.setFlags(int)
+
 **Breaking API Changes**
 
 **Known Issues**

--- a/core/java/androidx/test/core/api/current_public.txt
+++ b/core/java/androidx/test/core/api/current_public.txt
@@ -33,6 +33,7 @@ package androidx.test.core.content.pm {
   public final class ApplicationInfoBuilder {
     method public android.content.pm.ApplicationInfo! build();
     method public static androidx.test.core.content.pm.ApplicationInfoBuilder! newBuilder();
+    method public androidx.test.core.content.pm.ApplicationInfoBuilder! setFlags(int);
     method public androidx.test.core.content.pm.ApplicationInfoBuilder! setName(String?);
     method public androidx.test.core.content.pm.ApplicationInfoBuilder! setPackageName(String!);
   }

--- a/core/java/androidx/test/core/content/pm/ApplicationInfoBuilder.java
+++ b/core/java/androidx/test/core/content/pm/ApplicationInfoBuilder.java
@@ -24,6 +24,7 @@ import androidx.annotation.Nullable;
 public final class ApplicationInfoBuilder {
   @Nullable private String name;
   @Nullable private String packageName;
+  private int flags = 0;
 
   private ApplicationInfoBuilder() {}
 
@@ -58,11 +59,22 @@ public final class ApplicationInfoBuilder {
     return this;
   }
 
+  /**
+   * Sets the flags.
+   *
+   * @see ApplicationInfo#flags
+   */
+  public ApplicationInfoBuilder setFlags(int flags) {
+    this.flags = flags;
+    return this;
+  }
+
   /** Returns a {@link ApplicationInfo} with the provided data. */
   public ApplicationInfo build() {
     checkNotNull(packageName, "Mandatory field 'packageName' missing.");
 
     ApplicationInfo applicationInfo = new ApplicationInfo();
+    applicationInfo.flags = flags;
     applicationInfo.name = name;
     applicationInfo.packageName = packageName;
 

--- a/core/javatests/androidx/test/core/content/pm/ApplicationInfoBuilderTest.java
+++ b/core/javatests/androidx/test/core/content/pm/ApplicationInfoBuilderTest.java
@@ -31,12 +31,18 @@ public final class ApplicationInfoBuilderTest {
   public void buildAllFields() {
     String name = "TestName";
     String packageName = "test.package.name";
+    int flags = 0x00000001;
 
     ApplicationInfo applicationInfo =
-        ApplicationInfoBuilder.newBuilder().setName(name).setPackageName(packageName).build();
+        ApplicationInfoBuilder.newBuilder()
+            .setFlags(flags)
+            .setName(name)
+            .setPackageName(packageName)
+            .build();
 
     assertThat(applicationInfo.name).isEqualTo(name);
     assertThat(applicationInfo.packageName).isEqualTo(packageName);
+    assertThat(applicationInfo.flags).isEqualTo(flags);
   }
 
   @Test


### PR DESCRIPTION
### Overview
👋  Hi!
I'm currently trying to write a test for a class that consumes `ApplicationInfo.flags`.
Currently that is not writable by ApplicationInfoBuilder, therefore i was wondering if adding that capability would be acceptable. 

### Proposed Changes
- Add a setter for ApplicationInfo.flags in the Builder-Class