### PR TITLE
Inline gradle-wrapper-validation job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: 'Cache Bazel files'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-${{ env.cache-version }}-bazel-build-${{ github.sha }}
@@ -60,14 +60,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: 'Cache Bazel files'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-${{ env.cache-version }}-bazel-test-${{ github.sha }}
@@ -94,19 +94,19 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: Gradle wrapper validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Enable KVM group perms
         run: |
             echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
             sudo udevadm control --reload-rules
             sudo udevadm trigger --name-match=kvm       
       - name: 'Cache Gradle files'
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
       - name: 'Download local snapshot for tests'
         uses: actions/download-artifact@v4
         with:
@@ -118,7 +118,7 @@ jobs:
           unzip ~/download/axt_m2repository.zip -d ~/.m2/
         shell: bash
       - name: 'Setup Android SDK'
-        uses: android-actions/setup-android@v2
+        uses: android-actions/setup-android@v3
       - name: 'Run gradle tests'
         run: |
           cd ${{ github.workspace }}/gradle-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,12 @@ env:
   cache-version: v1
 
 jobs:
-  gradle-wrapper-validation:
-    name: gradle-wrapper-validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Java 17
         uses: actions/setup-java@v3
         with:
@@ -94,16 +88,18 @@ jobs:
         shell: bash
   gradle-emulator-test:
     runs-on: ubuntu-latest
-    needs: [build, gradle-wrapper-validation]
+    needs: [build]
     timeout-minutes: 20
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
+      - name: Gradle wrapper validation
+        uses: gradle/wrapper-validation-action@v1
       - name: Enable KVM group perms
         run: |
             echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
Just execute gradle-wrapper-validation in gradle-emulator-tests to save overhead of running a separate job with checkout.

Also update to actions/checkout@v4