### PR TITLE
Remove Orchestrator's single method fast path

### DIFF
--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
@@ -130,9 +130,6 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
   private static final String TEST_COLLECTION_FILENAME = "testCollection.txt";
   private static final int MAX_FILENAME_LENGTH = 255;
 
-  private static final Pattern FULLY_QUALIFIED_CLASS_AND_METHOD =
-      Pattern.compile("[\\w\\.?]+#\\w+");
-
   private static final List<String> RUNTIME_PERMISSIONS =
       Arrays.asList(permission.WRITE_EXTERNAL_STORAGE, permission.READ_EXTERNAL_STORAGE);
 
@@ -253,23 +250,14 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
       };
 
   private void collectTests() {
-    String classArg = arguments.getString(AJUR_CLASS_ARGUMENT);
-    // If we are given a single, fully qualified test then there's no point in test collection.
-    // Proceed as if we had done collection and gotten the single argument.
-    if (isSingleMethodTest(classArg)) {
-      Log.i(TAG, String.format("Single test parameter %s, skipping test collection", classArg));
-      callbackLogic.addTest(classArg);
-      runFinished();
-    } else {
-      Log.i(TAG, String.format("Multiple test parameter %s, starting test collection", classArg));
-      executorService.execute(
-          TestRunnable.testCollectionRunnable(
-              getContext(),
-              getSecret(arguments),
-              arguments,
-              getOutputStream(),
-              AndroidTestOrchestrator.this));
-    }
+    Log.i(TAG, "Starting test collection");
+    executorService.execute(
+        TestRunnable.testCollectionRunnable(
+            getContext(),
+            getSecret(arguments),
+            arguments,
+            getOutputStream(),
+            AndroidTestOrchestrator.this));
   }
 
   @VisibleForTesting
@@ -293,13 +281,6 @@ public final class AndroidTestOrchestrator extends android.app.Instrumentation
     return testName + testRunFilenameSuffix;
   }
 
-  @VisibleForTesting
-  static boolean isSingleMethodTest(String classArg) {
-    if (TextUtils.isEmpty(classArg)) {
-      return false;
-    }
-    return FULLY_QUALIFIED_CLASS_AND_METHOD.matcher(classArg).matches();
-  }
 
   /** Invoked every time the TestRunnable finishes, including after test collection. */
   @Override

--- a/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/AndroidTestOrchestratorTest.java
+++ b/runner/android_test_orchestrator/javatests/androidx/test/orchestrator/AndroidTestOrchestratorTest.java
@@ -27,26 +27,6 @@ import org.junit.runner.RunWith;
 /** Unit tests for {@link AndroidTestOrchestrator}. */
 @RunWith(AndroidJUnit4.class)
 public class AndroidTestOrchestratorTest {
-
-  @Test
-  public void testSingleMethodTest() {
-    assertThat(AndroidTestOrchestrator.isSingleMethodTest("org.example.class#method"), is(true));
-    assertThat(AndroidTestOrchestrator.isSingleMethodTest("org.example.class"), is(false));
-    assertThat(
-        AndroidTestOrchestrator.isSingleMethodTest("org.example.class,org.example.another#method"),
-        is(false));
-    assertThat(
-        AndroidTestOrchestrator.isSingleMethodTest(
-            "org.example.class#method,org.example.class#anotherMethod"),
-        is(false));
-  }
-
-  @Test
-  public void testSingleMethodTest_blankInput() {
-    assertThat(AndroidTestOrchestrator.isSingleMethodTest(null), is(false));
-    assertThat(AndroidTestOrchestrator.isSingleMethodTest(""), is(false));
-  }
-
   @Test
   public void testMakeValidFilename_notTooLong() {
     final int maxLength = 20;


### PR DESCRIPTION
### Overview

Fixes #2132.

Orchestrator has a fast path that skips test discovery if the test target is a single method. This doesn't work for parameterized tests, since even a single method target may expand to any number of parameterized test instances.

### Proposed Changes

Remove the fast path and always run test discovery, because I don't think it's possible to know ahead of time whether a test target expands to exactly 1 test.

Tested locally by running:

```
bazelisk build :axt_m2repository
unzip bazel-bin/axt_m2repository.zip -d ~/.m2/
```

and running one of the parameterised tests in our repo against the `1.5.0-alpha03` orchestrator artifacts in `~/.m2` (`mavenLocal()` in Gradle build scripts).