### PR TITLE
Evaluate TestRequestBuilder.CustomFilters also on class, not just on test.

### DIFF
--- a/runner/android_junit_runner/java/androidx/test/internal/runner/TestRequestBuilder.java
+++ b/runner/android_junit_runner/java/androidx/test/internal/runner/TestRequestBuilder.java
@@ -243,6 +243,15 @@ public class TestRequestBuilder {
   }
 
   private static class CustomFilters extends AbstractFilter {
+
+    @Override
+    public boolean shouldRun(Description description) {
+      if (description.isSuite() && !evaluateTest(description)) {
+        return false;
+      }
+      return super.shouldRun(description);
+    }
+
     @Override
     protected boolean evaluateTest(Description description) {
       Collection<Annotation> allAnnotations = description.getAnnotations();

--- a/runner/android_junit_runner/javatests/androidx/test/internal/runner/TestRequestBuilderTest.java
+++ b/runner/android_junit_runner/javatests/androidx/test/internal/runner/TestRequestBuilderTest.java
@@ -227,6 +227,50 @@ public class TestRequestBuilderTest {
     }
   }
 
+  @SampleCustomAnnotationOnClass(runTests = true)
+  public static class SampleCustomFilterOnClassRunTestsTestClass {
+    @Test
+    public void testOneRun() {}
+
+    @Test
+    public void testTwoRun() {}
+  }
+
+  @SampleCustomAnnotationOnClass(runTests = false)
+  public static class SampleCustomFilterOnClassSkipTestsTestClass {
+    @Test
+    public void testOneSkip() {}
+
+    @Test
+    public void testTwoSkip() {}
+  }
+
+  public static class SampleCustomFilterOnClass extends AbstractFilter {
+    public SampleCustomFilterOnClass() {}
+
+    @Override
+    public boolean shouldRun(Description description) {
+      return evaluateTest(description);
+    }
+
+    @Override
+    protected boolean evaluateTest(Description description) {
+      return description.getAnnotation(SampleCustomAnnotationOnClass.class).runTests();
+    }
+
+    @Override
+    public String describe() {
+      return "skip all tests in class if runTests is false";
+    }
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.TYPE})
+  @CustomFilter(filterClass = SampleCustomFilterOnClass.class)
+  public @interface SampleCustomAnnotationOnClass {
+    boolean runTests() default true;
+  }
+
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.TYPE, ElementType.METHOD})
   @CustomFilter(filterClass = SampleCustomFilter.class)
@@ -969,6 +1013,24 @@ public class TestRequestBuilderTest {
     JUnitCore testRunner = new JUnitCore();
     Result result = testRunner.run(request);
     Assert.assertEquals(1, result.getRunCount());
+  }
+
+  /** Test that {@link CustomFilter} filters the class as appropriate */
+  @Test
+  public void testCustomFilterAnnotation_onClass_runTests() {
+    Request request = builder.addTestClass(SampleCustomFilterOnClassRunTestsTestClass.class.getName()).build();
+    JUnitCore testRunner = new JUnitCore();
+    Result result = testRunner.run(request);
+    Assert.assertEquals(2, result.getRunCount());
+  }
+
+  /** Test that {@link CustomFilter} filters the class as appropriate */
+  @Test
+  public void testCustomFilterAnnotation_onClass_skipTests() {
+    Request request = builder.addTestClass(SampleCustomFilterOnClassSkipTestsTestClass.class.getName()).build();
+    JUnitCore testRunner = new JUnitCore();
+    Result result = testRunner.run(request);
+    Assert.assertEquals(0, result.getRunCount());
   }
 
   /** Test that a custom RunnerBuilder is used. */


### PR DESCRIPTION
Now `TestRequestBuilder.CustomFilters` does not evaluate `@CustomFilter` on test classes, just on tests. It will be great to have evaluation also for classes. 

Because of this missing feature, I need to apply my annotation with `@CustomFilter` to every test method, or I have to configure instrumentation runner in build.gradle.kts (or in my custom runner). All these solutions are kind of painful in large multimodule project.
```
android {
    defaultConfig {
        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
        testInstrumentationRunnerArguments["filter"] = listOf(
            "mypackage.MyCustomFilter",
        ).joinToString(separator = ",")
    }
}
```
or
```
class MyAndroidJUnitRunner : AndroidJUnitRunner() {

    override fun onCreate(arguments: Bundle) {
        arguments.putString("filter", MyCustomFilter::class.java.name)
        super.onCreate(arguments)
    }
}
```