### PR TITLE
Catch and log exceptions when enabling tracing.

### DIFF
--- a/runner/monitor/CHANGELOG.md
+++ b/runner/monitor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Bug Fixes**
 
+* Catch and log NoSuchMethodError on forceEnableAppTracing calls
+
 **New Features**
 
 **Breaking Changes**

--- a/runner/monitor/java/androidx/test/platform/tracing/AndroidXTracer.java
+++ b/runner/monitor/java/androidx/test/platform/tracing/AndroidXTracer.java
@@ -59,6 +59,12 @@ class AndroidXTracer implements Tracer {
       // The AndroidX call can fail if reflection is not allowed.
       // We want to log the error yet we should not break any test in this case.
       Log.e(TAG, "enableTracing failed", e);
+    } catch (NoSuchMethodError e) {
+      // This can occur if an androidx.tracing < 1.1.0 is put on classpath instead.
+      // See http://issuetracker.google.com/349628366).
+      // We want to log the error yet we should not break any test in this case.
+      Log.e(TAG, "enableTracing failed. "
+              + "You may need to upgrade your androidx.tracing:tracing version", e);
     }
     return this;
   }


### PR DESCRIPTION
Due to an android gradle bug calls to forceEnableAppTracing() may fail with NoSuchMethodError at runtime.
Instead of crashing, just catch and log this exception.


