### PR TITLE
Fix ActivityInvoker$-CC class not found errors.

### DIFF
--- a/runner/monitor/java/androidx/test/BUILD
+++ b/runner/monitor/java/androidx/test/BUILD
@@ -35,6 +35,7 @@ kt_android_library(
             "internal/runner/runtime/ExposedInstrumentationApi.java",
             "internal/runner/hidden/ExposedInstrumentationApi.java",
             "internal/platform/app/ActivityInvoker$$CC.java",
+            "internal/platform/app/ActivityInvokerDesugar.java",
         ],
     ),
     tags = ["alt_dep=//runner/monitor"],
@@ -81,6 +82,7 @@ android_library(
     srcs = [
         # only needed for external release backwards compatibility
         "internal/platform/app/ActivityInvoker$$CC.java",
+        "internal/platform/app/ActivityInvokerDesugar.java",
     ],
     custom_package = "androidx.test.monitor",
     manifest = "AndroidManifest.xml",
@@ -107,6 +109,7 @@ axt_android_aar(
         "androidx.test.platform",
         "androidx.test.runner",
     ],
+    jarjar_rule = ":jarjar.txt",
     included_dep = ":monitor_release_lib",
 )
 

--- a/runner/monitor/java/androidx/test/internal/platform/app/ActivityInvokerDesugar.java
+++ b/runner/monitor/java/androidx/test/internal/platform/app/ActivityInvokerDesugar.java
@@ -1,0 +1,40 @@
+package androidx.test.internal.platform.app;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.RestrictTo.Scope;
+
+/**
+ * Handles default implementation for ActivityInvoker#getIntentForActivity
+ *
+ * <p> See the {@link ActivityInvoker$$CC} javadoc for prior history.
+ *
+ * <p> Starting in androidx.test:monitor:1.6.X, a new version of the desugar tooling was used
+ * that generated a ActivityInvoker$-CC class. Class names with hyphens are rejected by javac,
+ * so we cannot directly declare a ActivityInvoker$-CC class here. So instead we use a
+ * placeholder name, and use jarjar to rename the class after the javac step.
+ *
+ * @hide
+ */
+@RestrictTo(Scope.LIBRARY_GROUP)
+public final class ActivityInvokerDesugar {
+
+  private ActivityInvokerDesugar() {}
+
+  public static Intent $default$getIntentForActivity(ActivityInvoker invoker,
+            Class<? extends Activity> activityClass) {
+    Intent intent =
+        Intent.makeMainActivity(
+            new ComponentName(getInstrumentation().getTargetContext(), activityClass));
+    if (getInstrumentation().getTargetContext().getPackageManager().resolveActivity(intent, 0)
+        != null) {
+      return intent;
+    }
+    return Intent.makeMainActivity(
+        new ComponentName(getInstrumentation().getContext(), activityClass));
+  }
+}

--- a/runner/monitor/java/androidx/test/jarjar.txt
+++ b/runner/monitor/java/androidx/test/jarjar.txt
@@ -1,0 +1,1 @@
+rule androidx.test.internal.platform.app.ActivityInvokerDesugar androidx.test.internal.platform.app.ActivityInvoker$-CC


### PR DESCRIPTION
Builds using ActivityScenario with older androidx.test.core:1.5.X but the latest androidx.test:monitor:1.7.X will see ActivityInvoker$-CC class not found errors. This is because androidx.test.core:1.5.X effectively depends on internal classes generated by the desugaring tool.

The latest androidx.test toolchain generates java8 bytecode and no longer generates these desugared classes.

To fix the backwards compatibility issues, this commit introduces a placeholder class ActivityInvokerDesugar that gets renamed to the missing ActivityInvoker$-CC class at build time.

Fixes #2259.

