### PR TITLE
Reword a precondition message

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,7 +7,7 @@
 **Bug Fixes**
 * Fix `Rect` handling in `ViewCapture` for SDK >= 34 for non root views.
 * Fix bug reporting the status code when PixelCopy fails in ViewCapture.generateBitmapFromPixelCopy.
-
+* Improving wording of a failure message.
 
 **New Features**
 

--- a/core/java/androidx/test/core/app/InstrumentationActivityInvoker.java
+++ b/core/java/androidx/test/core/app/InstrumentationActivityInvoker.java
@@ -289,7 +289,7 @@ class InstrumentationActivityInvoker implements ActivityInvoker {
       }
       checkNotNull(
           activityResult,
-          "onActivityResult never be called after %d milliseconds",
+          "onActivityResult was not called within %d milliseconds",
           ActivityLifecycleTimeout.getMillis());
       return activityResult;
     }


### PR DESCRIPTION
In "never be called after" the "be" is extraneous and should definitely be removed. I modified the entire phrase to what I think is more readable. If reviewers disagree, I can change this to only remove the "be" (or feel free to do it in a separate change).