### PR TITLE
Migrate tomcat's annotation-api to a new version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,7 +158,7 @@ maven_install(
         "com.squareup:javapoet:1.9.0",
         "io.grpc:grpc-okhttp:1.54.1",
         "io.grpc:grpc-stub:1.54.1",
-        "org.apache.tomcat:annotations-api:6.0.53",
+        "org.apache.tomcat:tomcat-annotations-api:10.0.0",
         "javax.annotation:javax.annotation-api:1.3.1",
         "javax.inject:javax.inject:1",
         "joda-time:joda-time:2.10.1",


### PR DESCRIPTION
Migrate org.apache.tomcat:annotations-api to
org.apache.tomcat:tommcat-annotations-api to use
newer versions that rename javax.annotation to
jakarta.annotation to avoid duplicated class
javax.annotation with other dependencies.

This CL selects the first stable version 10.0.0
that renames javax.annotation.

See https://github.com/apache/tomcat/commit/4ed2dc843a59ef204f93082d610f8d6f547051ab.
