### PR TITLE
Fix(espresso): Fix #2349

### DIFF
--- a/espresso/CHANGELOG.md
+++ b/espresso/CHANGELOG.md
@@ -16,6 +16,8 @@ The following artifacts were released:
 
 **Bug Fixes**
 
+Fix #2349, where multi-process + different rotation on 2 activities, would instantly timeout when waiting for the UI to rotate.
+
 **New Features**
 
 **Breaking Changes**

--- a/espresso/core/java/androidx/test/espresso/base/ConfigurationSynchronizationUtils.java
+++ b/espresso/core/java/androidx/test/espresso/base/ConfigurationSynchronizationUtils.java
@@ -27,6 +27,7 @@ import androidx.test.espresso.NoActivityResumedException;
 import androidx.test.espresso.UiController;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /** Helper methods to synchronize configuration changes with onView actions. */
 final class ConfigurationSynchronizationUtils {
@@ -52,7 +53,8 @@ final class ConfigurationSynchronizationUtils {
     }
     // If the application is running activities in different processes, activities that aren't
     // on the main process may have a different orientation
-    if (Build.VERSION.SDK_INT >= 28 && !currentActivity.getApplicationInfo().processName.equals(Application.getProcessName())) {
+    if (Build.VERSION.SDK_INT >= 28 && !Objects.equals(
+        currentActivity.getApplicationInfo().processName, Application.getProcessName())) {
       return;
     }
 

--- a/espresso/core/java/androidx/test/espresso/base/ConfigurationSynchronizationUtils.java
+++ b/espresso/core/java/androidx/test/espresso/base/ConfigurationSynchronizationUtils.java
@@ -18,6 +18,7 @@ package androidx.test.espresso.base;
 
 import static java.util.Collections.unmodifiableList;
 
+import android.app.Application;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
@@ -47,6 +48,11 @@ final class ConfigurationSynchronizationUtils {
     // The activity's orientation can differ from application's orientation when the activity is in
     // multi-window mode.
     if (Build.VERSION.SDK_INT >= 24 && currentActivity.isInMultiWindowMode()) {
+      return;
+    }
+    // If the application is running activities in different processes, activities that aren't
+    // on the main process may have a different orientation
+    if (Build.VERSION.SDK_INT >= 28 && !currentActivity.getApplicationInfo().processName.equals(Application.getProcessName())) {
       return;
     }
 


### PR DESCRIPTION
### Overview

This pull request fixes an issue I brought up a little while ago  (#2349) with multi-process + multi activity application that use different rotations between the activities.

### Proposed Changes
Since the processes are different, an early return is added to allow for activities on other processes to have a rotation different from the main process.

Note: the fix only works on API 28 or later due to limitations from the public API.