### PR TITLE
Update gradle-tests to use latest stable AGP 8.9 and gradle 8.11.1.

### DIFF
--- a/gradle-tests/build.gradle
+++ b/gradle-tests/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '8.5.0' apply false
+    id 'com.android.library' version '8.9.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
 }
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {

--- a/gradle-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 26 12:45:45 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The main motiviation is to ensure the tests are using a R8/D8 version that supports kotlin 2.1.0
https://developer.android.com/build/kotlin-support


