### PR TITLE
Cherrypick: Bazel: configure python to ignore root user error.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,11 +10,21 @@ bazel_dep(name = "rules_kotlin", version = "2.1.3", repo_name = "io_bazel_rules_
 bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
 bazel_dep(name = "grpc-java", version = GRPC_VERSION)
 bazel_dep(name = "rules_robolectric", version = "4.14.1.2", repo_name = "robolectric")
+bazel_dep(name = "rules_python", version = "1.2.0")
 
 # Pin the version of rules_robolectric so that it matches the robolectric version we get from maven.
 single_version_override(
     module_name = "rules_robolectric",
     version = "4.14.1.2",
+)
+
+# python setup
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+  is_default = True,
+  python_version = "3.12.8",
+  # See https://github.com/bazel-contrib/rules_python/issues/1169#issuecomment-1513804247
+  ignore_root_user_error = True,
 )
 
 # maven dependencies


### PR DESCRIPTION
PiperOrigin-RevId: 740053802

