### PR TITLE
Cherry-pick: Remove guava from orchestrator.

### DIFF
--- a/runner/android_test_orchestrator/CHANGELOG.md
+++ b/runner/android_test_orchestrator/CHANGELOG.md
@@ -6,9 +6,7 @@
 
 **Bug Fixes**
 
-* Fix a bug where the instrumentation test application would not startup if the
-arguments passed to `ORCHESTRATOR_FORWARDED_INSTRUMENTATION_ARGS` contains
-spaces.
+* Remove use of guava. Fixes https://github.com/android/android-test/issues/2422
 
 **New Features**
 

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/AndroidTestOrchestrator.java
@@ -16,6 +16,7 @@
 
 package androidx.test.orchestrator;
 
+import static androidx.test.internal.util.Checks.checkState;
 import static androidx.test.orchestrator.OrchestratorConstants.AJUR_CLASS_ARGUMENT;
 import static androidx.test.orchestrator.OrchestratorConstants.AJUR_COVERAGE;
 import static androidx.test.orchestrator.OrchestratorConstants.AJUR_COVERAGE_FILE;
@@ -24,7 +25,6 @@ import static androidx.test.orchestrator.OrchestratorConstants.COVERAGE_FILE_PAT
 import static androidx.test.orchestrator.OrchestratorConstants.ISOLATED_ARGUMENT;
 import static androidx.test.orchestrator.OrchestratorConstants.ORCHESTRATOR_DEBUG_ARGUMENT;
 import static androidx.test.orchestrator.OrchestratorConstants.TARGET_INSTRUMENTATION_ARGUMENT;
-import static com.google.common.base.Preconditions.checkState;
 
 import android.Manifest.permission;
 import android.app.Activity;

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/BUILD
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/BUILD
@@ -23,7 +23,6 @@ android_library(
         "//runner/android_junit_runner",
         "//services/shellexecutor:exec_client",
         "@maven//:androidx_core_core",
-        "@maven//:com_google_guava_guava",
     ],
 )
 

--- a/runner/android_test_orchestrator/java/androidx/test/orchestrator/CallbackLogic.java
+++ b/runner/android_test_orchestrator/java/androidx/test/orchestrator/CallbackLogic.java
@@ -16,18 +16,19 @@
 
 package androidx.test.orchestrator;
 
+import static androidx.test.internal.util.Checks.checkNotNull;
+import static androidx.test.internal.util.Checks.checkState;
+
 import android.os.Bundle;
 import androidx.test.orchestrator.callback.OrchestratorCallback;
 import androidx.test.orchestrator.listeners.OrchestrationListenerManager;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** Encapsulates all the logic for receiving callbacks from the app under test. */
 class CallbackLogic extends OrchestratorCallback.Stub {
   private static final String TAG = "CallbackLogic";
-  private static final Splitter CLASS_METHOD_SPLITTER = Splitter.on('#');
 
   private final List<String> listOfTests = new ArrayList<>();
   private final Object testLock = new Object();
@@ -38,7 +39,7 @@ class CallbackLogic extends OrchestratorCallback.Stub {
   @Override
   public void addTest(String test) {
     synchronized (testLock) {
-      List<String> classAndMethod = CLASS_METHOD_SPLITTER.splitToList(test);
+      List<String> classAndMethod = Arrays.asList(test.split("#"));
       if (classAndMethod.size() > 1
           && (classAndMethod.get(1).isEmpty() || classAndMethod.get(1).equals("null"))) {
         listOfTests.add(classAndMethod.get(0));
@@ -51,8 +52,7 @@ class CallbackLogic extends OrchestratorCallback.Stub {
   @Override
   public void sendTestNotification(Bundle bundle) {
     synchronized (testLock) {
-      Preconditions.checkNotNull(
-          listenerManager, "Unable to process test notification. No ListenerManager");
+      checkNotNull(listenerManager, "Unable to process test notification. No ListenerManager");
       listenerManager.handleNotification(bundle);
     }
   }
@@ -65,8 +65,8 @@ class CallbackLogic extends OrchestratorCallback.Stub {
 
   void setListenerManager(OrchestrationListenerManager mListenerManager) {
     synchronized (testLock) {
-      Preconditions.checkState(null == this.listenerManager, "Listener manager assigned twice.");
-      this.listenerManager = Preconditions.checkNotNull(mListenerManager, "Listener manager null");
+      checkState(null == this.listenerManager, "Listener manager assigned twice.");
+      this.listenerManager = checkNotNull(mListenerManager, "Listener manager null");
     }
   }
 }

--- a/runner/android_test_orchestrator/stubapp/BUILD
+++ b/runner/android_test_orchestrator/stubapp/BUILD
@@ -30,7 +30,6 @@ android_binary(
         "//runner/android_junit_runner",
         "//runner/android_test_orchestrator",
         "@maven//:androidx_multidex_multidex",
-        "@maven//:com_google_guava_guava",
         "@maven//:junit_junit",
     ],
 )


### PR DESCRIPTION
Use of guava is unnecessary and currently results in ClassNotFoundExceptions on APIs <= 23.

Fixes #2422

PiperOrigin-RevId: 789467366

